### PR TITLE
Parameterize execution fixes

### DIFF
--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -47,7 +47,7 @@ def cli_parser():
     parser.add_argument("--no-torsions", help="Do not perform torsion fitting (default: %(default)s)",
                         action="store_true", dest="notorsion", default=False)
     parser.add_argument("-e", "--exec", help="Mode of execution for the QM calculations (default: %(default)s)",
-                        choices=["inline", "LSF", "PBS", "Slurm", "AceCloud"], default="inline", dest="exec")
+                        choices=["inline", "LSF", "Slurm"], default="inline", dest="exec")
     parser.add_argument("--qmcode", help="QM code (default: %(default)s)", choices=["Gaussian", "PSI4", "TeraChem"],
                         default="PSI4", dest="qmcode")
     parser.add_argument("--freeze-charge", metavar="A1",
@@ -102,12 +102,8 @@ def main_parameterize(arguments=None):
         execution = Execution.Inline
     elif args.exec == "LSF":
         execution = Execution.LSF
-    elif args.exec == "PBS":
-        execution = Execution.PBS
     elif args.exec == "Slurm":
         execution = Execution.Slurm
-    elif args.exec == "AceCloud":
-        execution = Execution.AceCloud
     else:
         print("Unknown execution mode: {}".format(args.exec))
         sys.exit(1)

--- a/htmd/qm/qmcalculation.py
+++ b/htmd/qm/qmcalculation.py
@@ -49,9 +49,7 @@ class Code(Enum):
 class Execution(Enum):
     Inline = 4000
     LSF = 4001
-    PBS = 4002
     Slurm = 4003
-    AceCloud = 4004
 
 
 class QMResult:
@@ -371,15 +369,13 @@ class QMCalculation:
             elif execution == Execution.LSF:
                 execqueue = LsfQueue()
                 execqueue.queue = LsfQueue._defaults['{}_queue'.format(queue_type)]
-            # elif execution == Execution.PBS:
-            #      execqueue = PBSQueue(ncpu=self.ncpus, ngpu=1, memory=4000 )
+                execqueue.ncpu = self.ncpus
             elif execution == Execution.Slurm:
                 execqueue = SlurmQueue()
-                execqueue.partition = SlurmQueue._defaults['{}_queue'.format(queue_type)]
+                execqueue.partition = SlurmQueue._defaults['{}_partition'.format(queue_type)]
                 execqueue.ncpu = self.ncpus
-                execqueue.memory = 4000
-            elif execution == Execution.AceCloud:
-                execqueue = AceCloudQueue()
+            # elif execution == Execution.AceCloud:
+            #     execqueue = AceCloudQueue()
             else:
                 raise RuntimeError("Execution target not recognised")
 


### PR DESCRIPTION
* Removes PBS and AceCloud from parameterize client (and from qmcalculation)
* Fixes qmcalculation to correctly use SlurmQueue (partition and not queue) and PsfQueue (setting ncpu to ncpus)
* Fixes ngpu of LsfQueue and introduces ncpu to LsfQueue