### PR TITLE
Queue properties

### DIFF
--- a/htmd/queues/acecloudqueue.py
+++ b/htmd/queues/acecloudqueue.py
@@ -45,11 +45,13 @@ class AceCloudQueue(SimQueue, ProtocolInterface):
     """
     def __init__(self):
 
-        super().__init__()
+        SimQueue.__init__(self)
+        ProtocolInterface.__init__(self)
         self._arg('groupname', 'str', 'The name of the group of simulations you want to submit. If none is given, '
                                       'a randomly generated string will be used instead.', None, val.String())
         self._arg('datadir', 'str', 'The directory in which to retrieve your results.', None, val.String())
-        self._arg('requesttype', 'str', 'Choose between "spot" or "ondemand"', 'spot', val.String(), valid_values=('spot', 'ondemand'))
+        self._arg('requesttype', 'str', 'Choose between "spot" or "ondemand"', 'spot', val.String(),
+                  valid_values=('spot', 'ondemand'))
         self._arg('verbose', 'bool', 'Turn verbosity mode on or off.', False, val.Boolean())
 
         self._cloud = None
@@ -66,6 +68,7 @@ class AceCloudQueue(SimQueue, ProtocolInterface):
         from acecloud.job import Job
         if isinstance(dirs, str):
             dirs = [dirs, ]
+        self._dirs.extend(dirs)
 
         if self.groupname is None:
             self.groupname = ''.join(
@@ -77,9 +80,9 @@ class AceCloudQueue(SimQueue, ProtocolInterface):
                 raise FileExistsError('Submit: directory ' + d + ' does not exist.')
             runsh = os.path.join(d, 'run.sh')
             if not os.path.exists(runsh):
-                raise FileExistsError("File %s does not exist." % (runsh))
+                raise FileExistsError("File %s does not exist." % runsh)
             if not os.access(runsh, os.X_OK):
-                raise FileExistsError("File %s does not have execution permissions." % (runsh))
+                raise FileExistsError("File %s does not have execution permissions." % runsh)
 
         for d in dirs:
             logger.info("Queueing " + d)
@@ -106,9 +109,13 @@ class AceCloudQueue(SimQueue, ProtocolInterface):
         for j in jj:
             s = j.status()
             if s == Status.RUNNING or s == Status.PENDING:
-                count = count + 1
+                count += 1
 
         return count
+
+    def notcompleted(self):
+        # TODO: implement
+        pass
 
     def retrieve(self):
         if self.datadir is None:
@@ -148,3 +155,27 @@ class AceCloudQueue(SimQueue, ProtocolInterface):
             f.write('{}'.format(runsh))
 
         os.chmod(fname, 0o700)
+
+    @property
+    def ngpu(self):
+        raise NotImplementedError
+
+    @ngpu.setter
+    def ngpu(self, value):
+        raise NotImplementedError
+
+    @property
+    def ncpu(self):
+        raise NotImplementedError
+
+    @ncpu.setter
+    def ncpu(self, value):
+        raise NotImplementedError
+
+    @property
+    def memory(self):
+        raise NotImplementedError
+
+    @memory.setter
+    def memory(self, value):
+        raise NotImplementedError

--- a/htmd/queues/localqueue.py
+++ b/htmd/queues/localqueue.py
@@ -51,6 +51,7 @@ class _LocalQueue(SimQueue, ProtocolInterface):
             self._queue = queue.Queue()
 
             devices = self._getdevices()
+            self.memory = self._getmemory()
 
             self._threads = []
             for d in devices:
@@ -227,9 +228,11 @@ class LocalGPUQueue(_LocalQueue):
     ngpu : int, default=None
         Number of GPU devices that the queue will use. Each simulation will be run on a different GPU. The queue will
         use the first `ngpu` devices of the machine.
-
     devices : list, default=None
         A list of GPU device indexes on which the queue is allowed to run simulations. Mutually exclusive with `ngpu`
+    memory : int, default=None
+        The amount of RAM memory available for each job. If None, it will be guessed from total amount of memory and
+        the number of devices
 
 
     .. rubric:: Methods
@@ -249,7 +252,8 @@ class LocalGPUQueue(_LocalQueue):
         self._arg('devices', 'list', 'A list of GPU device indexes on which the queue is allowed to run '
                                      'simulations. Mutually exclusive with `ngpus`', None, val.Number(int, '0POS'),
                   nargs='*')
-        self._arg('memory', 'int', 'The amount of RAM memory available for each job.', self._getmemory(),
+        self._arg('memory', 'int', 'The amount of RAM memory available for each job. If None, it will be guessed from '
+                                   'total amount of memory and the number of devices', None,
                   val.Number(int, '0POS'))
 
     def _getdevices(self):
@@ -310,7 +314,9 @@ class LocalCPUQueue(_LocalQueue):
         A list of file names or globs for the files to copy to datadir
     ncpu : int, default=1
         Number of CPU threads that the queue will use.
-
+    memory : int, default=None
+        The amount of RAM memory available for each job. If None, it will be guessed from total amount of memory and
+        the number of devices
 
     .. rubric:: Methods
     .. autoautosummary:: htmd.queues.localqueue.LocalCPUQueue
@@ -325,7 +331,7 @@ class LocalCPUQueue(_LocalQueue):
         super().__init__()
         self._arg('ncpu', 'int', 'Number of CPU threads that the queue will use. If None it will use the `ncpu` '
                                  'configured for HTMD in htmd.configure()', None, val.Number(int, 'POS'))
-        self._arg('memory', 'int', 'The amount of RAM memory available for each job.', self._getmemory(),
+        self._arg('memory', 'int', 'The amount of RAM memory available for each job.', None,
                   val.Number(int, '0POS'))
 
     def _getdevices(self):

--- a/htmd/queues/localqueue.py
+++ b/htmd/queues/localqueue.py
@@ -8,15 +8,18 @@ from protocolinterface import ProtocolInterface, val
 import queue
 import threading
 from subprocess import check_output
-import os
 from glob import glob as glob
-import abc
+from abc import abstractmethod
 import logging
+import psutil
+from pint import UnitRegistry
 logger = logging.getLogger(__name__)
+
+# TODO: Merge CPU and GPU queue into a single one which manages ncpu and ngpu simultaneously
 
 
 class _LocalQueue(SimQueue, ProtocolInterface):
-    """ Local machine queue system
+    """ Support class for local machine queue systems
 
     Parameters
     ----------
@@ -24,21 +27,19 @@ class _LocalQueue(SimQueue, ProtocolInterface):
         The path in which to store completed trajectories.
     trajext : str, default='xtc'
         Extension of trajectory files. This is needed to copy them to datadir.
+    copy : list, default='*.xtc'
+        A list of file names or globs for the files to copy to datadir
 
-
-    .. rubric:: Methods
-    .. autoautosummary:: htmd.queues.localqueue._LocalQueue
-       :methods:
-    .. rubric:: Attributes
-    .. autoautosummary:: htmd.queues.localqueue._LocalQueue
-       :attributes:
     """
 
     def __init__(self):
-        super().__init__()
+        SimQueue.__init__(self)
+        ProtocolInterface.__init__(self)
         self._arg('datadir', 'str', 'The path in which to store completed trajectories.', None, val.String())
-        self._arg('trajext', 'str', 'Extension of trajectory files. This is needed to copy them to datadir.', 'xtc', val.String())
-        self._arg('copy', 'list', 'A list of file names or globs for the files to copy to datadir', ('*.xtc'), val.String(), nargs='*')
+        self._arg('trajext', 'str', 'Extension of trajectory files. This is needed to copy them to datadir.', 'xtc',
+                  val.String())
+        self._arg('copy', 'list', 'A list of file names or globs for the files to copy to datadir', ('*.xtc', ),
+                  val.String(), nargs='*')
         self._cmdDeprecated('trajext', 'copy')
 
         self._states = dict()
@@ -53,10 +54,45 @@ class _LocalQueue(SimQueue, ProtocolInterface):
 
             self._threads = []
             for d in devices:
-                t = threading.Thread(target=run_job, args=(self, d))
+                t = threading.Thread(target=self.run_job, args=(d, ))
                 t.daemon = True
                 t.start()
                 self._threads.append(t)
+
+    def run_job(self, gpuid):
+        queue = self._queue
+        while not self._shutdown:
+            path = None
+            try:
+                path = queue.get(timeout=1)
+            except:
+                pass
+
+            if path:
+                if gpuid is None:
+                    logger.info('Running ' + path)
+                else:
+                    logger.info("Running " + path + " on GPU device " + str(gpuid))
+                self._setRunning(path)
+
+                runsh = os.path.join(path, 'run.sh')
+                jobsh = os.path.join(path, 'job.sh')
+                self._createJobScript(jobsh, path, runsh, gpuid)
+
+                try:
+                    ret = check_output(jobsh)
+                    logger.debug(ret)
+                except Exception as e:
+                    logger.info('Error in simulation {}. {}'.format(path, e))
+                    self._setCompleted(path)
+                    queue.task_done()
+                    continue
+
+                logger.info("Completed " + path)
+                self._setCompleted(path)
+                queue.task_done()
+
+        logger.info("Shutting down worker thread")
 
     def _createJobScript(self, fname, workdir, runsh, gpudevice=None):
         with open(fname, 'w') as f:
@@ -117,7 +153,9 @@ class _LocalQueue(SimQueue, ProtocolInterface):
         """
         self._setupQueue()
 
-        if isinstance(mydirs, str): mydirs = [mydirs]
+        if isinstance(mydirs, str):
+            mydirs = [mydirs]
+        self._dirs.extend(mydirs)
 
         for d in mydirs:
             if not os.path.isdir(d):
@@ -144,12 +182,37 @@ class _LocalQueue(SimQueue, ProtocolInterface):
 
         return output_run + output_queue
 
+    def notcompleted(self):
+        """Returns the sum of the number of job directories which do not have the sentinel file for completion.
+
+        Returns
+        -------
+        total : int
+            Total number of directories which have not completed
+        """
+        total = 0
+        if len(self._dirs) == 0:
+            raise RuntimeError('This method relies on running synchronously.')
+        for i in self._dirs:
+            if not os.path.exists(os.path.join(i, self._sentinel)):
+                total += 1
+        return total
+
     def stop(self):
         self._shutdown = True
 
-    @abc.abstractmethod
+    @abstractmethod
     def _getdevices(self):
-        pass
+        return list()
+
+    def _getmemory(self):
+        ureg = UnitRegistry()
+        total_memory = int(ureg.Quantity(psutil.virtual_memory().total, ureg.byte).to('MiB').magnitude)
+        nr_devices = len(self._getdevices())
+        if nr_devices != 0:
+            return int(total_memory/nr_devices)
+        else:
+            return None
 
 
 class LocalGPUQueue(_LocalQueue):
@@ -162,9 +225,11 @@ class LocalGPUQueue(_LocalQueue):
     copy : list, default='*.xtc'
         A list of file names or globs for the files to copy to datadir
     ngpu : int, default=None
-        Number of GPU devices that the queue will use. Each simulation will be run on a different GPU. The queue will use the first `ngpus` devices of the machine.
+        Number of GPU devices that the queue will use. Each simulation will be run on a different GPU. The queue will
+        use the first `ngpu` devices of the machine.
+
     devices : list, default=None
-        A list of GPU device indexes on which the queue is allowed to run simulations. Mutually exclusive with `ngpus`
+        A list of GPU device indexes on which the queue is allowed to run simulations. Mutually exclusive with `ngpu`
 
 
     .. rubric:: Methods
@@ -179,10 +244,13 @@ class LocalGPUQueue(_LocalQueue):
     def __init__(self):
         super().__init__()
         self._arg('ngpu', 'int', 'Number of GPU devices that the queue will use. Each simulation will be run on '
-                                  'a different GPU. The queue will use the first `ngpus` devices of the machine.',
-                       None, val.Number(int, '0POS'))
+                                 'a different GPU. The queue will use the first `ngpus` devices of the machine.',
+                  None, val.Number(int, '0POS'))
         self._arg('devices', 'list', 'A list of GPU device indexes on which the queue is allowed to run '
-                                     'simulations. Mutually exclusive with `ngpus`', None, val.Number(int, '0POS'), nargs='*')
+                                     'simulations. Mutually exclusive with `ngpus`', None, val.Number(int, '0POS'),
+                  nargs='*')
+        self._arg('memory', 'int', 'The amount of RAM memory available for each job.', self._getmemory(),
+                  val.Number(int, '0POS'))
 
     def _getdevices(self):
         ngpu = self.ngpu
@@ -206,6 +274,30 @@ class LocalGPUQueue(_LocalQueue):
             logger.info("Using GPU devices {}".format(','.join(map(str, devices))))
         return devices
 
+    @property
+    def ngpu(self):
+        return self.__dict__['ngpu']
+
+    @ngpu.setter
+    def ngpu(self, value):
+        self.ngpu = value
+
+    @property
+    def ncpu(self):
+        raise NotImplementedError
+
+    @ncpu.setter
+    def ncpu(self, value):
+        raise NotImplementedError
+
+    @property
+    def memory(self):
+        return self.__dict__['memory']
+
+    @memory.setter
+    def memory(self, value):
+        self.memory = value
+
 
 class LocalCPUQueue(_LocalQueue):
     """ Local CPU machine queue system
@@ -216,8 +308,8 @@ class LocalCPUQueue(_LocalQueue):
         The path in which to store completed trajectories.
     copy : list, default='*.xtc'
         A list of file names or globs for the files to copy to datadir
-    ncpu : int, default=None
-        Number of CPU threads that the queue will use. If None it will use the `ncpu` configured for HTMD in htmd.configure()
+    ncpu : int, default=1
+        Number of CPU threads that the queue will use.
 
 
     .. rubric:: Methods
@@ -233,54 +325,41 @@ class LocalCPUQueue(_LocalQueue):
         super().__init__()
         self._arg('ncpu', 'int', 'Number of CPU threads that the queue will use. If None it will use the `ncpu` '
                                  'configured for HTMD in htmd.configure()', None, val.Number(int, 'POS'))
+        self._arg('memory', 'int', 'The amount of RAM memory available for each job.', self._getmemory(),
+                  val.Number(int, '0POS'))
 
     def _getdevices(self):
-        import multiprocessing
         ncpu = self.ncpu
-        totalcpus = multiprocessing.cpu_count()
+        totalcpus = psutil.cpu_count()
         if ncpu is None:
-            from htmd.config import _config
-            ncpu = totalcpus + _config['ncpus'] + 1
+            ncpu = totalcpus
         if ncpu > totalcpus:
             raise RuntimeError('You can only use up to {} threads on this machine'.format(totalcpus))
         return [None] * ncpu
 
+    @property
+    def ncpu(self):
+        return self.__dict__['ncpu']
 
-def run_job(self, gpuid):
-    queue = self._queue
-    while not self._shutdown:
-        path = None
-        try:
-            path = queue.get(timeout=1)
-        except:
-            pass
+    @ncpu.setter
+    def ncpu(self, value):
+        self.ncpu = value
 
-        if path:
-            if gpuid is None:
-                logger.info('Running ' + path)
-            else:
-                logger.info("Running " + path + " on GPU device " + str(gpuid))
-            self._setRunning(path)
+    @property
+    def ngpu(self):
+        raise NotImplementedError
 
-            runsh = os.path.join(path, 'run.sh')
-            jobsh = os.path.join(path, 'job.sh')
-            self._createJobScript(jobsh, path, runsh, gpuid)
+    @ngpu.setter
+    def ngpu(self, value):
+        raise NotImplementedError
 
-            try:
-                ret = check_output(jobsh)
-                logger.debug(ret)
-            except Exception as e:
-                logger.info('Error in simulation {}. {}'.format(path, e))
-                self._setCompleted(path)
-                queue.task_done()
-                continue
+    @property
+    def memory(self):
+        return self.__dict__['memory']
 
-            logger.info("Completed " + path)
-            self._setCompleted(path)
-            queue.task_done()
-
-    logger.info("Shutting down worker thread")
-
+    @memory.setter
+    def memory(self, value):
+        self.memory = value
 
 if __name__ == "__main__":
     from htmd.home import home
@@ -304,5 +383,3 @@ if __name__ == "__main__":
                 os.remove(r)
     except:
         print('No GPUs detected on this machine')
-
-

--- a/htmd/queues/lsfqueue.py
+++ b/htmd/queues/lsfqueue.py
@@ -29,7 +29,7 @@ class LsfQueue(SimQueue, ProtocolInterface):
     ncpu : int, default=1
         Number of CPUs to use for a single job
     memory : int, default=4000
-        Amount of memory per job (MB)
+        Amount of memory per job (MiB)
     walltime : int, default=None
         Job timeout (hour:min or min)
     environment : list of strings, default=None
@@ -54,12 +54,13 @@ class LsfQueue(SimQueue, ProtocolInterface):
                  'memory': 4000, 'walltime': None, 'resources': None, 'environment': None}
 
     def __init__(self):
-        super().__init__()
+        SimQueue.__init__(self)
+        ProtocolInterface.__init__(self)
         self._arg('jobname', 'str', 'Job name (identifier)', None, val.String())
         self._arg('queue', 'str', 'The queue to run on', self._defaults[self._defaults['default_queue']], val.String())
         self._arg('ngpu', 'int', 'Number of GPUs to use for a single job', self._defaults['ngpu'],
                   val.Number(int, '0POS'))
-        self._arg('ncpu', 'int', 'Number of GPUs to use for a single job', self._defaults['ncpu'],
+        self._arg('ncpu', 'int', 'Number of CPUs to use for a single job', self._defaults['ncpu'],
                   val.Number(int, '0POS'))
         self._arg('memory', 'int', 'Amount of memory per job (MB)', self._defaults['memory'], val.Number(int, '0POS'))
         self._arg('walltime', 'int', 'Job timeout (hour:min or min)', self._defaults['walltime'], val.Number(int, '0POS'))
@@ -76,10 +77,6 @@ class LsfQueue(SimQueue, ProtocolInterface):
         self._qinfo = LsfQueue._find_binary('bqueues')
         self._qcancel = LsfQueue._find_binary('bkill')
         self._qstatus = LsfQueue._find_binary('bjobs')
-
-        self._sentinel = 'htmd.queues.done'
-        # For synchronous
-        self._dirs = []
 
     @staticmethod
     def _find_binary(binary):
@@ -251,32 +248,30 @@ class LsfQueue(SimQueue, ProtocolInterface):
         ret = check_output(cmd)
         logger.debug(ret.decode("ascii"))
 
-    def wait(self, sentinel=False):
-        """ Blocks script execution until all queued work completes
+    @property
+    def ncpu(self):
+        return self.__dict__['ncpu']
 
-        Parameters
-        ----------
-        sentinel : bool, default=False
-            If False, it relies on the queueing system reporting to determine the number of running jobs. If True, it
-            relies on the filesystem, in particular on the existence of a sentinel file for job completion.
+    @ncpu.setter
+    def ncpu(self, value):
+        self.ncpu = value
 
-        Examples
-        --------
-        >>> LsfQueue.wait()
-        """
-        from time import sleep
-        import sys
+    @property
+    def ngpu(self):
+        return self.__dict__['ngpu']
 
-        while (self.inprogress() if not sentinel else self.notcompleted()) != 0:
-            sys.stdout.flush()
-            sleep(5)
+    @ngpu.setter
+    def ngpu(self, value):
+        self.ngpu = value
+
+    @property
+    def memory(self):
+        return self.__dict__['memory']
+
+    @memory.setter
+    def memory(self, value):
+        self.memory = value
+
 
 if __name__ == "__main__":
-    """
-    s=Slurm( name="testy", partition="gpu")
-    s.submit("test/dhfr1" )
-    ret= s.inprogress( debug=False)
-    print(ret)
-    print(s)
-    pass
-    """
+    q = LsfQueue()

--- a/htmd/queues/lsfqueue.py
+++ b/htmd/queues/lsfqueue.py
@@ -274,4 +274,7 @@ class LsfQueue(SimQueue, ProtocolInterface):
 
 
 if __name__ == "__main__":
+    # TODO: Create fake binaries for instance creation testing
+    """
     q = LsfQueue()
+    """

--- a/htmd/queues/simqueue.py
+++ b/htmd/queues/simqueue.py
@@ -3,41 +3,94 @@
 # Distributed under HTMD Software License Agreement
 # No redistribution in whole or part
 #
-import abc
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 
 
 class SimQueue(metaclass=ABCMeta):
 
-    @abc.abstractmethod
+    def __init__(self):
+        super().__init__()
+        self._sentinel = 'htmd.queues.done'
+        # For synchronous
+        self._dirs = []
+
+    @abstractmethod
     def retrieve(self):
         """ Subclasses need to implement this method """
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def submit(self, dirs):
         """ Subclasses need to implement this method """
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def inprogress(self):
         """ Subclasses need to implement this method """
         pass
 
-    def wait(self):
+    @abstractmethod
+    def notcompleted(self):
+        """ Subclasses need to implement this method """
+        pass
+
+    def wait(self, sentinel=False):
         """ Blocks script execution until all queued work completes
+
+        Parameters
+        ----------
+        sentinel : bool, default=False
+            If False, it relies on the queueing system reporting to determine the number of running jobs. If True, it
+            relies on the filesystem, in particular on the existence of a sentinel file for job completion.
 
         Examples
         --------
-        >>> queue.wait()
+        >>> self.wait()
         """
         from time import sleep
         import sys
-        while self.inprogress() != 0:
+
+        while (self.inprogress() if not sentinel else self.notcompleted()) != 0:
             sys.stdout.flush()
             sleep(5)
 
-    @abc.abstractmethod
+    @abstractmethod
     def stop(self):
         """ Subclasses need to implement this method """
+        pass
+
+    @property
+    @abstractmethod
+    def ncpu(self):
+        """ Subclasses need to have this property """
+        pass
+
+    @ncpu.setter
+    @abstractmethod
+    def ncpu(self, value):
+        """ Subclasses need to have this setter """
+        pass
+
+    @property
+    @abstractmethod
+    def ngpu(self):
+        """ Subclasses need to have this property """
+        pass
+
+    @ngpu.setter
+    @abstractmethod
+    def ngpu(self, value):
+        """ Subclasses need to have this setter """
+        pass
+
+    @property
+    @abstractmethod
+    def memory(self):
+        """ Subclasses need to have this property. This property is expected to return a integer in MiB"""
+        pass
+
+    @memory.setter
+    @abstractmethod
+    def memory(self, value):
+        """ Subclasses need to have this setter """
         pass

--- a/htmd/queues/slurmqueue.py
+++ b/htmd/queues/slurmqueue.py
@@ -305,4 +305,7 @@ class SlurmQueue(SimQueue, ProtocolInterface):
 
 
 if __name__ == "__main__":
+    # TODO: Create fake binaries for instance creation testing
+    """
     q = SlurmQueue()
+    """

--- a/htmd/queues/slurmqueue.py
+++ b/htmd/queues/slurmqueue.py
@@ -31,7 +31,7 @@ class SlurmQueue(SimQueue, ProtocolInterface):
     ncpu : int, default=1
         Number of CPUs to use for a single job
     memory : int, default=1000
-        Amount of memory per job (MB)
+        Amount of memory per job (MiB)
     gpumemory : int, default=None
         Only run on GPUs with at least this much memory. Needs special setup of SLURM. Check how to define gpu_mem on SLURM.
     walltime : int, default=None
@@ -67,13 +67,16 @@ class SlurmQueue(SimQueue, ProtocolInterface):
                  'ngpu': 1, 'ncpu': 1, 'memory': 1000, 'walltime': None, 'environment': 'ACEMD_HOME,HTMD_LICENSE_FILE'}
 
     def __init__(self):
-        super().__init__()
+        SimQueue.__init__(self)
+        ProtocolInterface.__init__(self)
         self._arg('jobname', 'str', 'Job name (identifier)', None, val.String())
         self._arg('partition', 'str', 'The queue (partition) to run on',
                   self._defaults[self._defaults['default_partition']], val.String())
         self._arg('priority', 'str', 'Job priority', self._defaults['priority'], val.String())
-        self._arg('ngpu', 'int', 'Number of GPUs to use for a single job', self._defaults['ngpu'], val.Number(int, '0POS'))
-        self._arg('ncpu', 'int', 'Number of CPUs to use for a single job', self._defaults['ncpu'], val.Number(int, 'POS'))
+        self._arg('ngpu', 'int', 'Number of GPUs to use for a single job', self._defaults['ngpu'],
+                  val.Number(int, '0POS'))
+        self._arg('ncpu', 'int', 'Number of CPUs to use for a single job', self._defaults['ncpu'],
+                  val.Number(int, 'POS'))
         self._arg('memory', 'int', 'Amount of memory per job (MB)', self._defaults['memory'], val.Number(int, 'POS'))
         self._arg('gpumemory', 'int', 'Only run on GPUs with at least this much memory. Needs special setup of SLURM. '
                                       'Check how to define gpu_mem on SLURM.', None, val.Number(int, '0POS'))
@@ -84,19 +87,18 @@ class SlurmQueue(SimQueue, ProtocolInterface):
         self._arg('outputstream', 'str', 'Output stream.', 'slurm.%N.%j.out', val.String())
         self._arg('errorstream', 'str', 'Error stream.', 'slurm.%N.%j.err'), val.String()  # Maybe change these to job name
         self._arg('datadir', 'str', 'The path in which to store completed trajectories.', None, val.String())
-        self._arg('trajext', 'str', 'Extension of trajectory files. This is needed to copy them to datadir.', 'xtc', val.String())
-        self._arg('nodelist', 'list', 'A list of nodes on which to run every job at the *same time*! Careful! The jobs will be duplicated!', None, val.String(), nargs='*')
-        self._arg('exclude', 'list', 'A list of nodes on which *not* to run the jobs. Use this to select nodes on which to allow the jobs to run on.', None, val.String(), nargs='*')
+        self._arg('trajext', 'str', 'Extension of trajectory files. This is needed to copy them to datadir.', 'xtc',
+                  val.String())
+        self._arg('nodelist', 'list', 'A list of nodes on which to run every job at the *same time*! Careful! The jobs'
+                                      ' will be duplicated!', None, val.String(), nargs='*')
+        self._arg('exclude', 'list', 'A list of nodes on which *not* to run the jobs. Use this to select nodes on '
+                                     'which to allow the jobs to run on.', None, val.String(), nargs='*')
 
         # Find executables
         self._qsubmit = SlurmQueue._find_binary('sbatch')
         self._qinfo = SlurmQueue._find_binary('sinfo')
         self._qcancel = SlurmQueue._find_binary('scancel')
         self._qstatus = SlurmQueue._find_binary('squeue')
-
-        self._sentinel = 'htmd.queues.done'
-        # For synchronous
-        self._dirs = []
 
     @staticmethod
     def _find_binary(binary):
@@ -277,33 +279,30 @@ class SlurmQueue(SimQueue, ProtocolInterface):
         ret = check_output(cmd)
         logger.debug(ret.decode("ascii"))
 
-    def wait(self, sentinel=False):
-        """ Blocks script execution until all queued work completes
+    @property
+    def ncpu(self):
+        return self.__dict__['ncpu']
 
-        Parameters
-        ----------
-        sentinel : bool, default=False
-            If False, it relies on the queueing system reporting to determine the number of running jobs. If True, it
-            relies on the filesystem, in particular on the existence of a sentinel file for job completion.
+    @ncpu.setter
+    def ncpu(self, value):
+        self.ncpu = value
 
-        Examples
-        --------
-        >>> SlurmQueue.wait()
-        """
-        from time import sleep
-        import sys
+    @property
+    def ngpu(self):
+        return self.__dict__['ngpu']
 
-        while (self.inprogress() if not sentinel else self.notcompleted()) != 0:
-            sys.stdout.flush()
-            sleep(5)
+    @ngpu.setter
+    def ngpu(self, value):
+        self.ngpu = value
+
+    @property
+    def memory(self):
+        return self.__dict__['memory']
+
+    @memory.setter
+    def memory(self, value):
+        self.memory = value
 
 
 if __name__ == "__main__":
-    """
-    s=Slurm( name="testy", partition="gpu")
-    s.submit("test/dhfr1" )
-    ret= s.inprogress( debug=False)
-    print(ret)
-    print(s)
-    pass
-    """
+    q = SlurmQueue()


### PR DESCRIPTION
Uniformization of SimQueues.  …
   * Creation of (abstract) generic properties that can be probed for any implemented SimQueue: ncpus, ngpus, memory
   * Generalization of the wait method (abstract method on SimQueue now), to include sentinel files and notcompleted mode (all in SimQueue)
   * super __init__ call replaced by separate calls to each parent, as it was not working (when I created an __init__ for SimQueue)
   * LocalQueues:
        - run_job converted into method
        - _getmemory method implemented
        - ncpus of LocalQueue detached from the ncpus of htmd

 TODO:
     - Merge LocalGPUQueue and LocalCPUQueue into a single class which manages both ncpu and ngpu simultaneously
     - Implement generic properties and notcompleted on AceCloudQueue