### PR TITLE
Fix localqueue. Missing 'import os. just restored'

### DIFF
--- a/htmd/queues/localqueue.py
+++ b/htmd/queues/localqueue.py
@@ -6,6 +6,7 @@
 from htmd.queues.simqueue import SimQueue
 from protocolinterface import ProtocolInterface, val
 import queue
+import os
 import threading
 from subprocess import check_output
 from glob import glob as glob


### PR DESCRIPTION
Just restored the import os in local queue