### PR TITLE
Stream file names no longer need to start with "toppar_[alfanum]+".

### DIFF
--- a/htmd/builder/charmm.py
+++ b/htmd/builder/charmm.py
@@ -747,9 +747,9 @@ def split(filename, outdir):
     filename : str
         Stream file name
     """
-    regex = re.compile('^toppar_(\w+)\.str$')
+    regex = re.compile('^(toppar_)?(.*)\.str$')
     base = os.path.basename(os.path.normpath(filename))
-    base = regex.findall(base)[0]
+    base = regex.findall(base)[0][1]
     outrtf = os.path.join(outdir, 'top_{}.rtf'.format(base))
     outprm = os.path.join(outdir, 'par_{}.prm'.format(base))
 


### PR DESCRIPTION
This is usefull to use parameters just as they come out of paramchem together with other cases. I think that it is not necessary to make the user rename all their str files  (I have 60 systems with different ligands) and there is no need for the "toppar_[alfanum]+" requirement.