### PR TITLE
Parameterize: fix atom type handling with "x"

### DIFF
--- a/htmd/parameterization/dihedral.py
+++ b/htmd/parameterization/dihedral.py
@@ -109,8 +109,7 @@ class DihedralFitting:
 
         # Duplicate the atom types of the dihedral
         for i in range(4):
-            if not ("x" in self.molecule._rtf.type_by_index[dihedral[i]]):
-                self.molecule._duplicateAtomType(dihedral[i])
+            self.molecule._duplicateAtomType(dihedral[i])
 
         equivalent_dihedrals = self._getEquivalentDihedrals(dihedral)
         if len(equivalent_dihedrals) > 1:


### PR DESCRIPTION
Duplicated atom types are named original_name + "x" + number, e.g. `ca` --> `cax0`. Fix the case if an atom type contains "x", so `cx` --> `cxx0`.