### PR TITLE
Parameterize: improve Psi4 and queue handling

### DIFF
--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -127,6 +127,7 @@ def main_parameterize(arguments=None):
         queue.hashnames = True
     else:
         raise NotImplementedError
+    queue.environment = 'PATH,LD_LIBRARY_PATH' # Use Psi4 from an active conda environment
 
     # Override default ncpus
     if args.ncpus:


### PR DESCRIPTION
- [ ] use Psi4 from an active conda environment
- [ ] pass queue memory in correct units