### PR TITLE
Adds limitation on LocalGPUQueue devices inheriting from CUDA_VISIBLE…

### DIFF
--- a/htmd/queues/localqueue.py
+++ b/htmd/queues/localqueue.py
@@ -292,8 +292,8 @@ class LocalGPUQueue(_LocalQueue):
             devices = range(ngpu)
 
         if devices is None:
-            raise NameError('Could not determine which GPUs to use. Specify the GPUs with the `ngpu` or `devices` '
-                            'parameters')
+            raise RuntimeError('Could not determine which GPUs to use. Specify the GPUs with the `ngpu` or `devices` '
+                               'parameters')
         else:
             visible_devices_str = os.getenv('CUDA_VISIBLE_DEVICES')
             if visible_devices_str is not None:

--- a/htmd/queues/simqueue.py
+++ b/htmd/queues/simqueue.py
@@ -8,6 +8,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class RetrieveError(Exception):
     def __init__(self, value):
         self.value = value


### PR DESCRIPTION
…_DEVICES environment variable

Not very important after all, since `nvidia-docker` images are already constrained at the `nvidia-smi` level, but I still think it's valuable.

Closes #566 