### PR TITLE
Fixing htmd-data release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 # Note on releases -- HTMD releases are now only made when a tag is pushed
 
-# Set MAKENOARCH=1 to the one combination which will make and release noarch packages. It's used in conda upload.
-
 sudo: required
 dist: trusty
 group: deprecated-2017Q4
 
+# BEFORE EDITING matrix: at least one build (and one only) needs MAKE_NOARCH=1 to upload the noarch packages to conda
 matrix:
   include:
     - os: linux
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.6 OSNAME=Linux
+      env: TRAVIS_PYTHON_VERSION=3.6 OSNAME=Linux MAKE_NOARCH=1
     - os: linux
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.5 OSNAME=Linux

--- a/package/htmd-data/meta.yaml
+++ b/package/htmd-data/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: htmd-data
-  version: "0.0.49"
+  version: "0.0.46"
 
 source:
    path: ../../htmd/data/


### PR DESCRIPTION
We haven't released htmd-data in 1 year, basically to it being lost in the modifications.

It was left unnoticed but now we're running tests at deployment sites, so now updated htmd-data is necessary (so many fails...).

Small change, quite urgent.

João