### PR TITLE
fftype needs to be consistent. if it returns mol it ought to be a copy

### DIFF
--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -149,6 +149,7 @@ def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCh
                 raise ValueError('Invalide method {}'.format(method))
 
     # Substituting values from the read-in topology
+    mol = mol.copy()
     mol.name = names
     mol.element = elements
     mol.atomtype = atomtypes


### PR DESCRIPTION
Right now it's modifying it in place and returning it which is very confusing. Since we have decided a while ago to not modify objects in-place inside functions (and methods only modify in place and don't return copies) this should also be consistent. I am sure I'll find a few more lying around at later points.