### PR TITLE
bugfix for fftype. Masses are usually correct length but zeros

### DIFF
--- a/htmd/data/test-param/benzamidine_cgenff/parameters/CGenFF_2b6/B3LYP-cc-pVDZ-vacuum/mol.psf
+++ b/htmd/data/test-param/benzamidine_cgenff/parameters/CGenFF_2b6/B3LYP-cc-pVDZ-vacuum/mol.psf
@@ -3,24 +3,24 @@ PSF
        0 !NTITLE
 
       18 !NATOM
-       1 L    1    MOL  C1   C261             1.0       0.0           0
-       2 L    1    MOL  C2   C261             0.0       0.0           0
-       3 L    1    MOL  C3   C261             0.0       0.0           0
-       4 L    1    MOL  C4   C261             0.0       0.0           0
-       5 L    1    MOL  C5   C261             0.0       0.0           0
-       6 L    1    MOL  C6   C261             0.0       0.0           0
-       7 L    1    MOL  C7   C2N2             0.0       0.0           0
-       8 L    1    MOL  H1   HG61             0.0       0.0           0
-       9 L    1    MOL  H2   HG61             0.0       0.0           0
-      10 L    1    MOL  H3   HG61             0.0       0.0           0
-      11 L    1    MOL  H4   HG61             0.0       0.0           0
-      12 L    1    MOL  H5   HG61             0.0       0.0           0
-      13 L    1    MOL  N1   N2P1             0.0       0.0           0
-      14 L    1    MOL  N2   N2P1             0.0       0.0           0
-      15 L    1    MOL  H6   HGP2             0.0       0.0           0
-      16 L    1    MOL  H7   HGP2             0.0       0.0           0
-      17 L    1    MOL  H8   HGP2             0.0       0.0           0
-      18 L    1    MOL  H9   HGP2             0.0       0.0           0
+       1 L    1    MOL  C1   C261             1.0    12.011           0
+       2 L    1    MOL  C2   C261             0.0    12.011           0
+       3 L    1    MOL  C3   C261             0.0    12.011           0
+       4 L    1    MOL  C4   C261             0.0    12.011           0
+       5 L    1    MOL  C5   C261             0.0    12.011           0
+       6 L    1    MOL  C6   C261             0.0    12.011           0
+       7 L    1    MOL  C7   C2N2             0.0    12.011           0
+       8 L    1    MOL  H1   HG61             0.0     1.008           0
+       9 L    1    MOL  H2   HG61             0.0     1.008           0
+      10 L    1    MOL  H3   HG61             0.0     1.008           0
+      11 L    1    MOL  H4   HG61             0.0     1.008           0
+      12 L    1    MOL  H5   HG61             0.0     1.008           0
+      13 L    1    MOL  N1   N2P1             0.0    14.007           0
+      14 L    1    MOL  N2   N2P1             0.0    14.007           0
+      15 L    1    MOL  H6   HGP2             0.0     1.008           0
+      16 L    1    MOL  H7   HGP2             0.0     1.008           0
+      17 L    1    MOL  H8   HGP2             0.0     1.008           0
+      18 L    1    MOL  H9   HGP2             0.0     1.008           0
 
 
 

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -155,7 +155,7 @@ def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCh
     mol.atomtype = atomtypes
     mol.charge = charges
     mol.impropers = impropers
-    if len(mol.masses) == 0:
+    if np.sum(mol.masses) == 0:
         mol.masses = masses
 
     return prm, mol


### PR DESCRIPTION
The check to substitute masses in fftype was wrong. Fixed it now