### PR TITLE
Small refactoring of FFEvaluate class

### DIFF
--- a/htmd/ffevaluation/ffevaluate.py
+++ b/htmd/ffevaluation/ffevaluate.py
@@ -16,6 +16,52 @@ def _formatEnergies(energies):
 
 class FFEvaluate:
     def __init__(self, mol, prm, betweensets=None, cutoff=0, rfa=False, solventDielectric=78.5, fromstruct=False):
+        """  Evaluates energies and forces of the forcefield for a given Molecule
+
+        Parameters
+        ----------
+        mol : :class:`Molecule <htmd.molecule.molecule.Molecule>` object
+            A Molecule object. Can contain multiple frames.
+        prm : :class:`ParameterSet <parmed.ParameterSet>` object
+            Forcefield parameters.
+        betweensets : tuple of strings
+            Only calculate energies between two sets of atoms given as atomselect strings.
+            Only computes LJ and electrostatics.
+        cutoff : float
+            If set to a value != 0 it will only calculate LJ, electrostatics and bond energies for atoms which are closer
+            than the threshold
+        rfa : bool
+            Use with `cutoff` to enable the reaction field approximation for scaling of the electrostatics up to the cutoff.
+            Uses the value of `solventDielectric` to model everything beyond the cutoff distance as solvent with uniform
+            dielectric.
+        solventDielectric : float
+            Used together with `cutoff` and `rfa`
+        fromstruct : bool
+            If the parameters were derived from a parmed Structure set to True. This option will be removed in the future
+            as it will be unnecessary.
+
+        Examples
+        --------
+        >>> from htmd.ffevaluation.test_ffevaluate import fixParameters, drawForce
+        >>> from htmd.ui import *
+        >>> import parmed
+        >>> mol = Molecule('./htmd/data/test-ffevaluate/waterbox/structure.psf')
+        >>> mol.read('./htmd/data/test-ffevaluate/waterbox/output.xtc')
+        >>> prm = parmed.charmm.CharmmParameterSet(fixParameters('./htmd/data/test-ffevaluate/waterbox/parameters.prm'))
+        >>> ffev = FFEvaluate(mol, prm, betweensets=('resname SOD', 'water'))
+        >>> energies, forces, atmnrg = ffev.calculate(mol.coords)
+
+        You can visualize the force vectors in VMD
+        >>> mol.view()
+        >>> for cc, ff in zip(mol.coords[:, :, 0], forces[:, :, 0]):
+        >>>     drawForce(cc, ff)
+
+        Amber style
+        >>> prmtop = parmed.amber.AmberParm('structure.prmtop')
+        >>> prm = parmed.amber.AmberParameterSet.from_structure(prmtop)
+        >>> ffev = FFEvaluate(mol, prm, betweensets=('resname SOD', 'water'), fromstruct=True)
+        >>> energies, forces, atmnrg = ffev.calculate(mol.coords)
+        """
         mol = mol.copy()
         setA, setB = calculateSets(mol, betweensets)
 
@@ -36,6 +82,26 @@ class FFEvaluate:
         return _formatEnergies(energies[:, 0].squeeze())
 
     def calculate(self, coords, box=None):
+        """ Calculates energies, forces and individual atom energies for given coordinates and periodic box.
+
+        Parameters
+        ----------
+        coords : np.ndarray
+            A (natoms, 3, nframes) shaped coordinates array.
+        box : np.ndarray
+            A (3, nframes) shaped periodic box dimensions array.
+
+        Returns
+        -------
+        energies : np.ndarray
+            A (6, nframes) shaped matrix containing the individual energy components of each simulation frame.
+            Rows correspond to the following energies 0: bond 1: LJ 2: Electrostatic 3: angle 4: dihedral 5: improper
+        forces : np.ndarray
+            A (natoms, 3, nframes) shaped matrix containing the total force on each atom for each simulation frame.
+        atmnrg : np.ndarray
+            A (natoms, 6, nframes) shaped matrix containing the approximate potential energy components of each atom at each
+            simulation frame. The 6 indexes are the same as in the `energies` return argument.
+        """
         if coords.ndim == 2:
             coords = coords[:, :, np.newaxis].copy()
 
@@ -212,90 +278,6 @@ def calculateSets(mol, betweensets):
         mol.dihedral = np.empty((0, 4), dtype=np.uint32)
         mol.improper = np.empty((0, 4), dtype=np.uint32)
     return setA, setB
-
-
-def ffevaluate(mol, prm, betweensets=None, cutoff=0, rfa=False, solventDielectric=78.5, threads=1, fromstruct=False):
-    """  Evaluates energies and forces of the forcefield for a given Molecule
-
-    Parameters
-    ----------
-    mol : :class:`Molecule <htmd.molecule.molecule.Molecule>` object
-        A Molecule object. Can contain multiple frames.
-    prm : :class:`ParameterSet <parmed.ParameterSet>` object
-        Forcefield parameters.
-    betweensets : tuple of strings
-        Only calculate energies between two sets of atoms given as atomselect strings.
-        Only computes LJ and electrostatics.
-    cutoff : float
-        If set to a value != 0 it will only calculate LJ, electrostatics and bond energies for atoms which are closer
-        than the threshold
-    rfa : bool
-        Use with `cutoff` to enable the reaction field approximation for scaling of the electrostatics up to the cutoff.
-        Uses the value of `solventDielectric` to model everything beyond the cutoff distance as solvent with uniform
-        dielectric.
-    solventDielectric : float
-        Used together with `cutoff` and `rfa`
-
-    Returns
-    -------
-    energies : np.ndarray
-        A (6, nframes) shaped matrix containing the individual energy components of each simulation frame.
-        Rows correspond to the following energies 0: bond 1: LJ 2: Electrostatic 3: angle 4: dihedral 5: improper
-    forces : np.ndarray
-        A (natoms, 3, nframes) shaped matrix containing the total force on each atom for each simulation frame.
-    atmnrg : np.ndarray
-        A (natoms, 6, nframes) shaped matrix containing the approximate potential energy components of each atom at each
-        simulation frame. The 6 indexes are the same as in the `energies` return argument.
-
-    Examples
-    --------
-    >>> from htmd.ffevaluation.ffevaluate import *
-    >>> from htmd.ffevaluation.test_ffevaluate import fixParameters, drawForce
-    >>> from htmd.ui import *
-    >>> import parmed
-    >>> mol = Molecule('./htmd/data/test-ffevaluate/waterbox/structure.psf')
-    >>> mol.read('./htmd/data/test-ffevaluate/waterbox/output.xtc')
-    >>> prm = parmed.charmm.CharmmParameterSet(fixParameters('./htmd/data/test-ffevaluate/waterbox/parameters.prm'))
-    >>> energies, forces, atmnrg = ffevaluate(mol, prm, betweensets=('resname SOD', 'water'))
-
-    >>> mol.view()
-    >>> for cc, ff in zip(mol.coords[:, :, 0], forces[:, :, 0]):
-    >>>     drawForce(cc, ff)
-
-    Amber style
-    >>> prmtop = parmed.amber.AmberParm('structure.prmtop')
-    >>> prm = parmed.amber.AmberParameterSet.from_structure(prmtop)
-    >>> energies, forces, atmnrg = ffevaluate(mol, prm, betweensets=('resname SOD', 'water'))
-    """
-    if mol.box.shape[0] != 3 or mol.box.shape[1] != mol.coords.shape[2]:
-        raise ValueError('Box dimensions have to be (3, numFrames), your Molecule has box of shape {}'.format(mol.box.shape))
-
-    mol = mol.copy()
-    coords = mol.coords.astype(np.float32)
-    box = mol.box.astype(np.float32)
-    setA, setB = calculateSets(mol, betweensets)
-
-    args = list(init(mol, prm, fromstruct))
-    args.append(setA)
-    args.append(setB)
-    args.append(cutoff)
-    args.append(rfa)
-    args.append(solventDielectric)
-
-    if threads == 1:
-        energies, forces, atmnrg = _ffevaluate(coords, box, *args)
-    else:
-        from htmd.parallelprogress import ParallelExecutor, delayed
-        aprun = ParallelExecutor(n_jobs=threads)
-        res = aprun(total=mol.numFrames, desc='Evaluating energies')(
-            delayed(_ffevaluate)(np.atleast_3d(coords[:, :, f]),
-                                 box[:, f].reshape(3, 1),
-                                 *args) for f in range(mol.numFrames))
-        energies = np.hstack([r[0] for r in res])
-        forces = np.concatenate([r[1] for r in res], axis=2)
-        atmnrg = np.concatenate([r[2] for r in res], axis=2)
-
-    return energies, forces, atmnrg
 
 
 @jit('boolean(int64[:, :], int64, int64)', nopython=True)

--- a/htmd/ffevaluation/ffevaluate.py
+++ b/htmd/ffevaluation/ffevaluate.py
@@ -35,7 +35,7 @@ class FFEvaluate:
         energies, _, _ = self.calculate(coords, box)
         return _formatEnergies(energies[:, 0].squeeze())
 
-    def calculate(self, coords, box):
+    def calculate(self, coords, box=None):
         if coords.ndim == 2:
             coords = coords[:, :, np.newaxis].copy()
 

--- a/htmd/ffevaluation/test_ffevaluate.py
+++ b/htmd/ffevaluation/test_ffevaluate.py
@@ -1,5 +1,5 @@
 from htmd.molecule.molecule import Molecule
-from htmd.ffevaluation.ffevaluate import ffevaluate
+from htmd.ffevaluation.ffevaluate import FFEvaluate
 import parmed
 from glob import glob
 import numpy as np
@@ -264,7 +264,7 @@ if __name__ == '__main__':
                 keepForces(prm, struct, mol, forces=force)
                 keepForcesAmber(struct, mol, forces=force)
 
-            energies, forces, atmnrg = ffevaluate(mol, prm, fromstruct=fromstruct, cutoff=cutoff, rfa=rfa)
+            energies, forces, atmnrg = FFEvaluate(mol, prm, fromstruct=fromstruct, cutoff=cutoff, rfa=rfa).calculate(mol.coords, mol.box)
             energies = _formatEnergies(energies[:, 0])
             forces = forces[:, :, 0].squeeze()
             omm_energies, omm_forces = openmm_energy(prm, struct, coords, box=mol.box, cutoff=cutoff)
@@ -282,7 +282,7 @@ if __name__ == '__main__':
             fromstruct = True
             keepForces(prm, struct, mol)
             keepForcesAmber(struct, mol)
-        energies, forces, atmnrg = ffevaluate(mol, prm, fromstruct=fromstruct, cutoff=cutoff, rfa=rfa)
+        energies, forces, atmnrg = FFEvaluate(mol, prm, fromstruct=fromstruct, cutoff=cutoff, rfa=rfa).calculate(mol.coords, mol.box)
         energies = _formatEnergies(energies[:, 0])
         forces = forces[:, :, 0].squeeze()
         omm_energies, omm_forces = openmm_energy(prm, struct, coords, box=mol.box, cutoff=cutoff)

--- a/htmd/ffevaluation/test_ffevaluate.py
+++ b/htmd/ffevaluation/test_ffevaluate.py
@@ -203,7 +203,6 @@ def fixParameters(parameterfile):
 
 if __name__ == '__main__':
     from natsort import natsorted
-    from htmd.ffevaluation.ffevaluate import _formatEnergies
     from htmd.home import home
     from htmd.molecule.molecule import Molecule
     from glob import glob
@@ -265,7 +264,7 @@ if __name__ == '__main__':
                 keepForcesAmber(struct, mol, forces=force)
 
             energies, forces, atmnrg = FFEvaluate(mol, prm, fromstruct=fromstruct, cutoff=cutoff, rfa=rfa).calculate(mol.coords, mol.box)
-            energies = _formatEnergies(energies[:, 0])
+            energies = FFEvaluate.formatEnergies(energies[:, 0])
             forces = forces[:, :, 0].squeeze()
             omm_energies, omm_forces = openmm_energy(prm, struct, coords, box=mol.box, cutoff=cutoff)
             ediff = compareEnergies(energies, omm_energies, abstol=abstol)
@@ -283,7 +282,7 @@ if __name__ == '__main__':
             keepForces(prm, struct, mol)
             keepForcesAmber(struct, mol)
         energies, forces, atmnrg = FFEvaluate(mol, prm, fromstruct=fromstruct, cutoff=cutoff, rfa=rfa).calculate(mol.coords, mol.box)
-        energies = _formatEnergies(energies[:, 0])
+        energies = FFEvaluate.formatEnergies(energies[:, 0])
         forces = forces[:, :, 0].squeeze()
         omm_energies, omm_forces = openmm_energy(prm, struct, coords, box=mol.box, cutoff=cutoff)
         ediff = compareEnergies(energies, omm_energies, abstol=abstol)

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -77,7 +77,7 @@ def getArgumentParser():
 def printEnergies(molecule, parameters, filename):
     from htmd.ffevaluation.ffevaluate import FFEvaluate
     assert molecule.numFrames == 1
-    energies = FFEvaluate(molecule, parameters).run(molecule.coords[:, :, 0])
+    energies = FFEvaluate(molecule, parameters).getEnergies(molecule.coords[:, :, 0])
 
     string = '''
 == Diagnostic Energies ==

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -77,7 +77,7 @@ def getArgumentParser():
 def printEnergies(molecule, parameters, filename):
     from htmd.ffevaluation.ffevaluate import FFEvaluate
     assert molecule.numFrames == 1
-    energies = FFEvaluate(molecule, parameters).getEnergies(molecule.coords[:, :, 0])
+    energies = FFEvaluate(molecule, parameters).calculateEnergies(molecule.coords[:, :, 0])
 
     string = '''
 == Diagnostic Energies ==

--- a/htmd/parameterization/dihedral.py
+++ b/htmd/parameterization/dihedral.py
@@ -152,7 +152,7 @@ class DihedralFitting:
         ff = FFEvaluate(self.molecule, self.parameters)
         self._initial_energies = []
         for rotamer_coords in self._coords:
-            self._initial_energies.append(np.array([ff.getEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords]))
+            self._initial_energies.append(np.array([ff.calculateEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords]))
 
     def _getBounds(self):
         """
@@ -315,7 +315,7 @@ class DihedralFitting:
         self._target_energies = []
         ff = FFEvaluate(self.molecule, self.parameters)
         for rotamer_coords, ref_energies in zip(self._coords, self._reference_energies):
-            energies = ref_energies - np.array([ff.getEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords])
+            energies = ref_energies - np.array([ff.calculateEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords])
             energies -= np.min(energies)
             self._target_energies.append(energies)
         self._all_target_energies = np.concatenate(self._target_energies)
@@ -338,7 +338,7 @@ class DihedralFitting:
         self._fitted_energies = []
         ffeval = FFEvaluate(self.molecule, self.parameters)
         for rotamer_coords in self._coords:
-            self._fitted_energies.append(np.array([ffeval.getEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords]))
+            self._fitted_energies.append(np.array([ffeval.calculateEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords]))
 
         # TODO make the self-consistency test numerically robust
         #reference_energies = np.concatenate([energies - np.mean(energies) for energies in self._reference_energies])

--- a/htmd/parameterization/dihedral.py
+++ b/htmd/parameterization/dihedral.py
@@ -152,7 +152,7 @@ class DihedralFitting:
         ff = FFEvaluate(self.molecule, self.parameters)
         self._initial_energies = []
         for rotamer_coords in self._coords:
-            self._initial_energies.append(np.array([ff.run(coords[:, :, 0])['total'] for coords in rotamer_coords]))
+            self._initial_energies.append(np.array([ff.getEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords]))
 
     def _getBounds(self):
         """
@@ -315,7 +315,7 @@ class DihedralFitting:
         self._target_energies = []
         ff = FFEvaluate(self.molecule, self.parameters)
         for rotamer_coords, ref_energies in zip(self._coords, self._reference_energies):
-            energies = ref_energies - np.array([ff.run(coords[:, :, 0])['total'] for coords in rotamer_coords])
+            energies = ref_energies - np.array([ff.getEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords])
             energies -= np.min(energies)
             self._target_energies.append(energies)
         self._all_target_energies = np.concatenate(self._target_energies)
@@ -338,7 +338,7 @@ class DihedralFitting:
         self._fitted_energies = []
         ffeval = FFEvaluate(self.molecule, self.parameters)
         for rotamer_coords in self._coords:
-            self._fitted_energies.append(np.array([ffeval.run(coords[:, :, 0])['total'] for coords in rotamer_coords]))
+            self._fitted_energies.append(np.array([ffeval.getEnergies(coords[:, :, 0])['total'] for coords in rotamer_coords]))
 
         # TODO make the self-consistency test numerically robust
         #reference_energies = np.concatenate([energies - np.mean(energies) for energies in self._reference_energies])

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -136,7 +136,7 @@ class FakeQM(QMBase):
 
                 if self.optimize:
                     opt = nlopt.opt(nlopt.LN_COBYLA, result.coords.size)
-                    opt.set_min_objective(lambda x, _: ff.run(x.reshape((-1, 3)))['total'])
+                    opt.set_min_objective(lambda x, _: ff.getEnergies(x.reshape((-1, 3)))['total'])
                     if self.restrained_dihedrals is not None:
                         for dihedral in self.restrained_dihedrals:
                             indices = dihedral.copy()
@@ -152,7 +152,7 @@ class FakeQM(QMBase):
                     result.coords = opt.optimize(result.coords.ravel()).reshape((-1, 3, 1))
                     logger.info('Optimization status: %d' % opt.last_optimize_result())
 
-                result.energy = ff.run(result.coords[:, :, 0])['total']
+                result.energy = ff.getEnergies(result.coords[:, :, 0])['total']
                 result.dipole = getDipole(self.molecule)
 
                 if self.optimize:

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -136,7 +136,7 @@ class FakeQM(QMBase):
 
                 if self.optimize:
                     opt = nlopt.opt(nlopt.LN_COBYLA, result.coords.size)
-                    opt.set_min_objective(lambda x, _: ff.getEnergies(x.reshape((-1, 3)))['total'])
+                    opt.set_min_objective(lambda x, _: ff.calculateEnergies(x.reshape((-1, 3)))['total'])
                     if self.restrained_dihedrals is not None:
                         for dihedral in self.restrained_dihedrals:
                             indices = dihedral.copy()
@@ -152,7 +152,7 @@ class FakeQM(QMBase):
                     result.coords = opt.optimize(result.coords.ravel()).reshape((-1, 3, 1))
                     logger.info('Optimization status: %d' % opt.last_optimize_result())
 
-                result.energy = ff.getEnergies(result.coords[:, :, 0])['total']
+                result.energy = ff.calculateEnergies(result.coords[:, :, 0])['total']
                 result.dipole = getDipole(self.molecule)
 
                 if self.optimize:

--- a/htmd/ui.py
+++ b/htmd/ui.py
@@ -47,6 +47,7 @@ from htmd.queues.lsfqueue import LsfQueue
 from htmd.queues.pbsqueue import PBSQueue
 from htmd.vmdgraphics import VMDConvexHull, VMDBox, VMDIsosurface, VMDSphere, VMDText
 from htmd.builder.loopmodeler import loopModeller
+from htmd.ffevaluation.ffevaluate import FFEvaluate
 from htmdx.cli import check_registration, show_news
 from htmd.latest import compareVersions
 from htmd.config import config


### PR DESCRIPTION
 to be able to get all results and renamed methods.

I really dislike the name `run` in this case and also run only returned energies while ffevaluate calculates also forces and atom energies. So now `calculate` returns everything and `getEnergies` only the formatted energies.