### PR TITLE
Fixes part of commit 0742ae4a329e352aa3e2688d08d6b56648fa2a39

### DIFF
--- a/htmd/model.py
+++ b/htmd/model.py
@@ -450,6 +450,8 @@ class Model(object):
             plt.savefig(save, dpi=300, bbox_inches='tight', pad_inches=0.2)
         if plot:
             plt.show()
+        else:
+            plt.close()
         return macroeq
 
     def _coarseP(self):

--- a/htmd/model.py
+++ b/htmd/model.py
@@ -439,19 +439,19 @@ class Model(object):
             # macroeq[i] = np.sum(self.msm.stationary_distribution[self.macro_ofmicro == i])
             macroeq[i] = np.sum(self.msm.metastable_memberships[:, macroindexes[i]] * self.msm.stationary_distribution)
 
-        from matplotlib import pylab as plt
-        plt.figure()
-        plt.bar(range(self.macronum), macroeq)
-        plt.ylabel('Equilibrium probability')
-        plt.xlabel('Macrostates')
-        plt.xticks(np.arange(0.4, self.macronum+0.4, 1), range(self.macronum))
+        if plot or (save is not None):
+            from matplotlib import pylab as plt
+            plt.ion()
+            plt.figure()
+            plt.bar(range(self.macronum), macroeq)
+            plt.ylabel('Equilibrium probability')
+            plt.xlabel('Macrostates')
+            plt.xticks(np.arange(0.4, self.macronum+0.4, 1), range(self.macronum))
+            if save is not None:
+                plt.savefig(save, dpi=300, bbox_inches='tight', pad_inches=0.2)
+            if plot:
+                plt.show()
 
-        if save is not None:
-            plt.savefig(save, dpi=300, bbox_inches='tight', pad_inches=0.2)
-        if plot:
-            plt.show()
-        else:
-            plt.close()
         return macroeq
 
     def _coarseP(self):


### PR DESCRIPTION
Just a bug I found while reviewing the tutorials that `Kinetics` and its methods was printing a plot of eqDistribution, despite plot=False in the code.

Let's fix this one and I'll open an issue to check plotting in general in 1.14.x.