### PR TITLE
Parameterize: fix logger configuration

### DIFF
--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -9,6 +9,7 @@ import argparse
 import logging
 import numpy as np
 
+import htmd.ui # This is needed to configure logging
 from htmd.version import version
 from htmd.queues.localqueue import LocalCPUQueue
 from htmd.queues.slurmqueue import SlurmQueue


### PR DESCRIPTION
Parameterize logger message are silenced, if `htmd.ui` is not imported, which, as a side effect, configures loggers.