### PR TITLE
fixed some minor printing in parameterize

### DIFF
--- a/htmd/parameterization/parameterset.py
+++ b/htmd/parameterization/parameterset.py
@@ -11,7 +11,7 @@ def getParameter(type, parameterfield):
     type = tuple(reversed(type))
     if type in parameterfield:
         return parameterfield[type]
-    print(parameterfield[type])  # Throw the correct error
+    raise RuntimeError('Could not find parameters for key {}'.format(type))
 
 
 def getImproperParameter(type, parameters):
@@ -118,10 +118,8 @@ def inventAtomTypes(mol, fit_dihedrals, equivalents):
 
         equivalent_dihedrals = _getEquivalentDihedrals(mol, equivalents, np.array(dih))
         if len(equivalent_dihedrals) > 1:
-            print(dih)
-            print(len(equivalent_dihedrals))
-            print(equivalent_dihedrals)
-            raise ValueError("Dihedral term still not unique after duplication")
+            raise ValueError("Dihedral term still not unique after duplication. Dihedral {} has {} equivalent "
+                             "dihedrals: {}".format(dih, len(equivalent_dihedrals), equivalent_dihedrals))
 
     return mol, originaltype
 

--- a/htmd/parameterization/readers.py
+++ b/htmd/parameterization/readers.py
@@ -1,6 +1,9 @@
 import numpy as np
 import re
 from htmd.parameterization.parameterset import _ATOM_TYPE_REG_EX
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _guessElement(name):
@@ -65,7 +68,7 @@ def readRTF(filename):
         name = names[idx]
         if atype not in element_by_type:
             element_by_type[atype] = _guessElement(name)
-            print("Guessing element %s for atom %s type %s" % (element_by_type[atype], name, atype))
+            logger.info("Guessing element %s for atom %s type %s" % (element_by_type[atype], name, atype))
         if atype not in mass_by_type:
             mass_by_type[atype] = _guessMass(element_by_type[atype])
 


### PR DESCRIPTION
I was trying to replace the printing in parameterize with logging but in the end gave up on `cli.py` because multiline logging is actually discouraged in python and all prints there are multiline.

In any case, these minor things that I changed are better this way so I thought we should merge it