### PR TITLE
fix adaptive base for saving PDBs

### DIFF
--- a/htmd/adaptive/adaptive.py
+++ b/htmd/adaptive/adaptive.py
@@ -233,13 +233,8 @@ def _writeInputsFunction(i, f, epoch, inputpath, coorname):
     copytree(currSim.input, newDir, symlinks=False, ignore=ignore_patterns('*.coor', '*.rst', '*.out', *_IGNORE_EXTENSIONS))
 
     # overwrite input file with new one. frameNum + 1 as catdcd does 1 based indexing
-    from htmd.molecule.readers import _MDTRAJ_TRAJECTORY_EXTS
-    import os
-    if os.path.splitext(traj)[1].split('.')[1].lower() in _MDTRAJ_TRAJECTORY_EXTS:
-        # MDtraj trajectory. Unfortunately we need to read the topology to read the trajectory.
-        mol = Molecule(currSim.molfile)
-    else:
-        mol = Molecule()
+
+    mol = Molecule(currSim.molfile)  # Always read the mol file, otherwise it does not work if we need to save a PDB as coorname
     mol.read(traj)
     mol.dropFrames(keep=frameNum)  # Making sure only specific frame to write is kept
     mol.write(path.join(newDir, coorname))


### PR DESCRIPTION
Simplify the writing of new coordinates that works also when the new coordinate file is a PDB.

The previous optimization is probably not important as this is not a critical part for performance