### PR TITLE
Add Iron aliases for charmm build

### DIFF
--- a/htmd/builder/charmm.py
+++ b/htmd/builder/charmm.py
@@ -398,6 +398,8 @@ def _printAliases(f):
         pdbalias residue CA CAL
         pdbalias atom CA CA CAL
         pdbalias residue ZN ZN2
+        pdbalias residue FE2 Fe2p
+        pdbalias atom Fe2p FE Fe2p 
 
         # Other aliases
         pdbalias atom LYS 1HZ HZ1


### PR DESCRIPTION
Added another alias for iron ion. Required for the acemd tests