### PR TITLE
Removing default fstep from readers

### DIFF
--- a/htmd/projections/metric.py
+++ b/htmd/projections/metric.py
@@ -168,12 +168,12 @@ class Metric:
                            'If it looks wrong, you can modify it by manually '
                            'setting the MetricData.fstep property.'.format(', '.join(map(str,uqfsteps)), data.fstep))
         else:
-            logger.info('Frame step {}ns was read from the trajectories. If it looks wrong, redefine it by manually '
-                        'setting the MetricData.fstep property.'.format(data.fstep))
-
-        if data.fstep == 0:
-            logger.warning('A fstep of 0 was read from the trajectories. Please manually set the MetricData.fstep'
-                           ' property, otherwise calculations in Model and Kinetics classes can fail.')
+            if data.fstep == 0:
+                logger.warning('A fstep of 0 was read from the trajectories. Please manually set the MetricData.fstep'
+                               ' property, otherwise calculations in Model and Kinetics classes can fail.')
+            else:
+                logger.info('Frame step {}ns was read from the trajectories. If it looks wrong, redefine it by manually '
+                            'setting the MetricData.fstep property.'.format(data.fstep))
 
         return data
 

--- a/htmd/projections/metric.py
+++ b/htmd/projections/metric.py
@@ -171,6 +171,10 @@ class Metric:
             logger.info('Frame step {}ns was read from the trajectories. If it looks wrong, redefine it by manually '
                         'setting the MetricData.fstep property.'.format(data.fstep))
 
+        if data.fstep == 0:
+            logger.warning('A fstep of 0 was read from the trajectories. Please manually set the MetricData.fstep'
+                           ' property, otherwise calculations in Model and Kinetics classes can fail.')
+
         return data
 
     def _projectSingle(self, index):


### PR DESCRIPTION
Removed defaults of 0.1ps fstep. Throws warning when fstep is 0 in metricdata

Taking care of issue:
https://github.com/Acellera/htmd/issues/642#event-1568766560