### PR TITLE
Making model and kinetics not depend on fstep

### DIFF
--- a/htmd/model.py
+++ b/htmd/model.py
@@ -82,6 +82,8 @@ class Model(object):
         self._integrityCheck(markov=True)
 
         lag = unitconvert(units, 'frames', lag, fstep=self.data.fstep)
+        if lag == 0:
+            raise RuntimeError('A lag time of 0 frames cannot be used to build a model. This could be caused by 0 in your MetricData.fstep.')
 
         self.lag = lag
         self.msm = msm.estimate_markov_model(self.data.St.tolist(), self.lag, sparse=sparse)
@@ -259,6 +261,8 @@ class Model(object):
             lags = self._defaultLags()
         else:
             lags = unitconvert(units, 'frames', lags, fstep=self.data.fstep).tolist()
+            if np.all(lags == 0):
+                raise RuntimeError('A lag time of 0 frames cannot be used to plot Timescales. This could be caused by 0 in your MetricData.fstep.')
 
         if nits is None:
             nits = np.min((self.data.K, 20))
@@ -270,7 +274,10 @@ class Model(object):
             plt.ion()
             plt.figure()
             try:
-                mplt.plot_implied_timescales(its, dt=self.data.fstep, units='ns')
+                if self.data.fstep == 0:
+                    mplt.plot_implied_timescales(its)
+                else:
+                    mplt.plot_implied_timescales(its, dt=self.data.fstep, units='ns')
             except ValueError as ve:
                 plt.close()
                 raise ValueError('{} This is probably caused by badly set fstep in the data ({}). '.format(ve, self.data.fstep) +

--- a/htmd/projections/tica.py
+++ b/htmd/projections/tica.py
@@ -82,7 +82,7 @@ class TICA(object):
         else:  # In-memory TICA
             lag = unitconvert(units, 'frames', lag, data.fstep)
             if lag == 0:
-                raise RuntimeError('Lag time conversion resulted in 0 frames. Please use a larger lag-time for TICA.')
+                raise RuntimeError('Lag time conversion resulted in 0 frames. Please use a larger lag-time for TICA or check if the MetricData.fstep property is set correctly.')
 
             self.tic = TICApyemma(lag)
             if self.dimensions is None:


### PR DESCRIPTION
As per @giadefa comments in PR https://github.com/Acellera/htmd/pull/646 I am trying to make Model and Kinetics work with frames as units. 

- [x] Model
- [ ] Kinetics

Kinetics is a bit trickier because our Rates class just stores pure values. The units are just printed in the console. The Koff and Kon for example are on seconds while the mfpts in nanoseconds. With frames I could have mfpts in frames but I would need to change the calculation for the Kon and Koff to also be in frames and not 1e9 frames which would be pointless.

Ideally I would like to propose using in HTMD something like the units in openmm which package values together with their units as an object and allows for easy conversions and less mistakes.