### PR TITLE
change tutorial tests to only run tests starting in test_tutorial

### DIFF
--- a/tutorials/test_tutorials.py
+++ b/tutorials/test_tutorials.py
@@ -8,7 +8,6 @@ from nbconvert import PythonExporter
 from glob import glob
 import os
 import pytest
-import htmd
 
 
 def test_tutorials(testfolder, tutorials=('ligand-binding-analysis', 'protein-folding-analysis')):
@@ -37,7 +36,7 @@ def test_tutorials(testfolder, tutorials=('ligand-binding-analysis', 'protein-fo
             with open(os.path.join(testsubf, 'test_{}.py'.format(name)), 'w') as fo:
                 fo.writelines(format_script(output, testsubf, name))
 
-    return pytest.main([testfolder])
+    return pytest.main(['-k', 'test_tutorial', testfolder])
 
 
 def format_script(script, outdir, name):
@@ -46,7 +45,7 @@ def format_script(script, outdir, name):
 
     splitt = script.split('\n')
     lines = ['from htmd.ui import *\n',
-             'def test_{}():\n'.format(name.replace('-', '_')),
+             'def test_tutorial_{}():\n'.format(name.replace('-', '_')),
              '\tgetCurrentViewer(dispdev="text")\n',
              '\tnp.random.seed(0)\n',
              '\timport os\n',


### PR DESCRIPTION
This is just a bug fix, without the permanent solution yet.

My experience with the test_tutorials function is that pytest is not only collecting the 2 test functions we have, but also the `from htmd.ui import *` at the top of each file. This is the work around I found, by using the -k argument: it still collects them, but it does not run them.

This fix makes my release job easier, as it reduces release time from ~ 5 hours to ~ 1 hour.

There was no issue associated with this.