### PR TITLE
Silence pyemma version warnings

### DIFF
--- a/htmd/ui.py
+++ b/htmd/ui.py
@@ -76,7 +76,7 @@ import warnings
 # Get rid of pyemma version warnings
 with warnings.catch_warnings():
     warnings.simplefilter('ignore', category=UserWarning)
-    from pyemma import coordinates
+    import pyemma
 
 
 

--- a/htmd/ui.py
+++ b/htmd/ui.py
@@ -71,7 +71,12 @@ if not (os.getenv("HTMD_NONINTERACTIVE")):
 
 # from matplotlib import pylab as plt
 # ----------------------------
+import warnings
 
+# Get rid of pyemma version warnings
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', category=UserWarning)
+    from pyemma import coordinates
 
 
 


### PR DESCRIPTION
Really the other PR was overkill. Those warnings are only thrown on the first import. So we might as well just import it once with a wrapper in `htmd.ui` and be done with it.