### PR TITLE
condensed the element guess warning

### DIFF
--- a/htmd/molecule/readers.py
+++ b/htmd/molecule/readers.py
@@ -219,6 +219,7 @@ def MOL2read(filename, frame=None, topoloc=None):
 
     # TODO: Error on bad format (using pandas?)
     natoms = end - start + 1
+    unguessed = []
     for i in range(natoms):
         s = l[i + start].strip().split()
         topo.record.append("HETATM")
@@ -236,9 +237,12 @@ def MOL2read(filename, frame=None, topoloc=None):
         if element in element_symbols:
             topo.element.append(element)
         else:
-            logger.warning('Element of atom ID {} could not be automatically guessed from its '
-                           'MOL2 atomtype ({}).'.format(int(s[0]), s[5]))
+            unguessed.append(s[5])
             topo.element.append('')
+    if len(unguessed) != 0:
+        logger.warning('Could not guess elements for {} atoms with MOL2 atomtypes '
+                       '({}).'.format(len(unguessed), ', '.join(np.unique(unguessed))))
+
     if bond:
         for i in range(bond, len(l)):
             b = l[i].split()


### PR DESCRIPTION
I got sick of screens full of mol2 warnings so I condensed this:

```
2018-04-26 12:33:34,594 - htmd.molecule.readers - WARNING - Element of atom ID 1 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,594 - htmd.molecule.readers - WARNING - Element of atom ID 2 could not be automatically guessed from its MOL2 atomtype (za).
2018-04-26 12:33:34,594 - htmd.molecule.readers - WARNING - Element of atom ID 3 could not be automatically guessed from its MOL2 atomtype (zb).
2018-04-26 12:33:34,594 - htmd.molecule.readers - WARNING - Element of atom ID 4 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,594 - htmd.molecule.readers - WARNING - Element of atom ID 5 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 6 could not be automatically guessed from its MOL2 atomtype (zb).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 7 could not be automatically guessed from its MOL2 atomtype (za).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 8 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 9 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 10 could not be automatically guessed from its MOL2 atomtype (nb).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 11 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 12 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 13 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 14 could not be automatically guessed from its MOL2 atomtype (ca).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 15 could not be automatically guessed from its MOL2 atomtype (zc).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 16 could not be automatically guessed from its MOL2 atomtype (zc).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 17 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 18 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 19 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 20 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 21 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 22 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 23 could not be automatically guessed from its MOL2 atomtype (ha).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 24 could not be automatically guessed from its MOL2 atomtype (zd).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 25 could not be automatically guessed from its MOL2 atomtype (zd).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 26 could not be automatically guessed from its MOL2 atomtype (zd).
2018-04-26 12:33:34,595 - htmd.molecule.readers - WARNING - Element of atom ID 27 could not be automatically guessed from its MOL2 atomtype (zd).
```

to this
```
2018-04-26 12:40:54,936 - htmd.molecule.readers - WARNING - Could not guess elements for 27 atoms with MOL2 atomtypes (ca, ha, nb, za, zb, zc, zd).
```