### PR TITLE
fixes bug in preparation that pandas does not like

### DIFF
--- a/htmd/builder/preparationdata.py
+++ b/htmd/builder/preparationdata.py
@@ -130,7 +130,7 @@ class PreparationData:
             self.data.at[pos, key] = val
         else:
             try:
-                ov = self.data.iloc[pos][key]
+                ov = list(self.data.iloc[pos][key])
                 if type(ov) == float and math.isnan(ov):
                     ov = list()
             except:


### PR DESCRIPTION
This solves the issue with pandas 0.23. I'm still not sure why it didn't error on py3.5 but it did on py3.6 (maybe pandas got updated in between one build and the other? that's unlucky), but ensuring that the value `ov` is already a list when `append=True` makes sense.

Testing locally with updated pandas 0.23 pass (while fail on 0.22). Let's hope they pass on Travis too.