### PR TITLE
Fix for AMBER uncapped terminals crashing tleap

### DIFF
--- a/htmd/builder/amber.py
+++ b/htmd/builder/amber.py
@@ -563,6 +563,14 @@ def _applyProteinCaps(mol, caps):
             mol.remove('segid {} and resid "{}" and name {}'.format(seg, orig_terminalresids[i], ' '.join(terminalatoms[cap])),
                        _logger=False)
 
+    # Remove terminal hydrogens regardless of caps or no caps. tleap confuses itself when it makes residues into terminals.
+    # For example HID has an atom H which in NHID should become H[123] and crashes tleap.
+    for seg in np.unique(mol.get('segid', 'protein')):
+        segidm = mol.segid == seg  # Mask for segid
+        segididx = np.where(segidm)[0]
+        resids = mol.resid[segididx]
+        mol.remove('(resid "{}" "{}") and segid {} and hydrogen'.format(resids[0], resids[-1], seg), _logger=False)
+
 
 def _removeProteinBonds(mol):
     segs = np.unique(mol.segid[mol.atomtype != ''])  # Keeping bonds related to mol2 files


### PR DESCRIPTION
So if you try to build a protein in AMBER which doesn't have caps you will run into the issue that the caps have different atom names for the hydrogens.
For example if you have a terminal HID residue with a H atom, once tleap tried to build it it will rename it to NHID and crash because there is no H atom in NHID, just H[123].
Removing all hydrogens from all terminals was the easiest solution. According to @cuzzo87 it should not matter anyway as the H positions in terminals are equivalent.