### PR TITLE
Added support for multimol Mol2 files

### DIFF
--- a/htmd/molecule/molecule.py
+++ b/htmd/molecule/molecule.py
@@ -806,7 +806,7 @@ class Molecule:
         self.moveBy(-com)
         self.moveBy(loc)
 
-    def read(self, filename, type=None, skip=None, frames=None, append=False, overwrite='all', keepaltloc='A', guess=None, guessNE=None, _logger=True):
+    def read(self, filename, type=None, skip=None, frames=None, append=False, overwrite='all', keepaltloc='A', guess=None, guessNE=None, _logger=True, **kwargs):
         """ Read any supported file. Currently supported files include pdb, psf, prmtop, prm, pdbqt, xtc, coor, xyz,
         mol2, gjf, mae, and crd, as well as all others supported by MDTraj.
 
@@ -882,7 +882,7 @@ class Molecule:
             readers = _ALL_READERS[ext]
             for rr in readers:
                 try:
-                    to, tr = rr(fname, frame=frame, topoloc=tmppdb)
+                    to, tr = rr(fname, frame=frame, topoloc=tmppdb, **kwargs)
                 except FormatError:
                     continue
                 else:

--- a/htmd/molecule/readers.py
+++ b/htmd/molecule/readers.py
@@ -225,6 +225,9 @@ def MOL2read(filename, frame=None, topoloc=None, singlemol=True):
             if line.startswith('@<TRIPOS>BOND'):
                 section = 'bond'
                 continue
+            if line.startswith('@<TRIPOS>'):  # Skip all other sections
+                section = None
+                continue
 
             if section == 'atom':
                 pieces = line.strip().split()


### PR DESCRIPTION
Updated the old mol2 reader. Made it able to read multimol files.
Molecule class will still not be able to read multimol files since this will require a decent redesign of stuff. But at least if someone wishes to use the reader directly to read multiple mol2 molecules he can. 
I'll probably make another PR later that allows `Molecule.read` to read and return multiple molecules.