### PR TITLE
Fixes one bug in ringpenetration and many errors in lgtm

### DIFF
--- a/htmd/builder/charmm.py
+++ b/htmd/builder/charmm.py
@@ -987,7 +987,6 @@ if __name__ == '__main__':
     import unittest
     unittest.main()
 
-    from htmd.ui import *
     import doctest
     doctest.testmod()
 

--- a/htmd/membranebuilder/ringpenetration.py
+++ b/htmd/membranebuilder/ringpenetration.py
@@ -96,10 +96,10 @@ def _checkAtomsPenetrating(coords2, bonds2, ringcoords, axis, ringcom, maxd, box
                 continue
 
             d = 0
-            for i in range(0, ringcoords.shape[0]):
-                p1 = ringcoords[i] - p
+            for k in range(0, ringcoords.shape[0]):
+                p1 = ringcoords[k] - p
                 try:
-                    p2 = ringcoords[i + 1] - p
+                    p2 = ringcoords[k + 1] - p
                 except:
                     p2 = ringcoords[0] - p
                 d += np.arccos(np.dot(p1, p2) / np.linalg.norm(p1) / np.linalg.norm(p2))

--- a/htmd/metricdata.py
+++ b/htmd/metricdata.py
@@ -19,7 +19,7 @@ def _getsizes(x):
             return len(x)
 
 
-class Trajectory:
+class Trajectory(object):
     def __init__(self, projection=None, reference=None, sim=None, cluster=None):
         self._projection = projection
         self._reference = reference
@@ -95,7 +95,7 @@ class Trajectory:
             'np.array(shape={})'.format(np.shape(self.cluster)) if self.cluster is not None else None)
 
 
-class MetricData:
+class MetricData(object):
     """ Class used for storing projected trajectories, their clustering and state assignments. Objects of this class
     are constructed by the `project` methods of the other projection classes. Only construct this class if you want to
     load saved data.

--- a/htmd/model.py
+++ b/htmd/model.py
@@ -16,7 +16,6 @@ import numpy as np
 from scipy import stats
 import warnings
 import random
-from htmd.projections.metric import _singleMolfile
 from htmd.molecule.molecule import Molecule
 from htmd.vmdviewer import getCurrentViewer
 from htmd.units import convert as unitconvert
@@ -502,6 +501,7 @@ class Model(object):
         >>> for m in mols:
         >>>     m.view()
         """
+        from htmd.projections.metric import _singleMolfile
         self._integrityCheck(postmsm=(statetype != 'cluster'))
         if simlist is None:
             simlist = self.data.simlist

--- a/htmd/molecule/pdbx/reader/PdbxParser.py
+++ b/htmd/molecule/pdbx/reader/PdbxParser.py
@@ -275,7 +275,7 @@ class PdbxReader(object):
                     curRow = []
                     curCategory.append(curRow)
 
-                    for tAtt in curCategory.getAttributeList():
+                    for _ in curCategory.getAttributeList():
                         if curWord is not None:
                             curRow.append(curWord)
                         elif curQuotedString is not None:

--- a/htmd/molecule/pdbx/reader/PdbxReader.py
+++ b/htmd/molecule/pdbx/reader/PdbxReader.py
@@ -264,7 +264,7 @@ class PdbxReader(object):
                     curRow = []
                     curCategory.append(curRow)
 
-                    for tAtt in curCategory.getAttributeList():
+                    for _ in curCategory.getAttributeList():
                         if curWord is not None:
                             curRow.append(curWord)
                         elif curQuotedString is not None:

--- a/htmd/molecule/readers.py
+++ b/htmd/molecule/readers.py
@@ -27,7 +27,7 @@ class FormatError(Exception):
         return repr(self.value)
 
 
-class Topology:
+class Topology(object):
     def __init__(self, pandasdata=None):
         self.record = []
         self.serial = []
@@ -76,7 +76,7 @@ class Topology:
             self.__dict__[field] = data
 
 
-class Trajectory:
+class Trajectory(object):
     def __init__(self, coords=None, box=None, boxangles=None, fileloc=None, step=None, time=None):
         self.coords = []
         self.box = []
@@ -121,7 +121,7 @@ class TopologyInconsistencyError(Exception):
     def __str__(self):
         return repr(self.value)
 
-class MolFactory:
+class MolFactory(object):
     """ This class converts Topology and Trajectory data into Molecule objects """
     @staticmethod
     def construct(topos, trajs, filename, frame):

--- a/htmd/pathplanning.py
+++ b/htmd/pathplanning.py
@@ -353,4 +353,4 @@ def _viewSphere(spherecoor):
     spheremol = Molecule()
     spheremol.empty(spherecoor.shape[0])
     spheremol.coords = np.atleast_3d(spherecoor)
-    spheremol.view(guessbonds=False)
+    spheremol.view(guessBonds=False)

--- a/htmd/smallmol/smallmol.py
+++ b/htmd/smallmol/smallmol.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 print('SmallMol module is in beta version')
 
 
-class SmallMol:
+class SmallMol(object):
     """
     Class to manipulate small molecule structures
 
@@ -1394,7 +1394,7 @@ def unwrap_self(arg, **kwarg):
     return SmallMolLib.vox_fun(arg[0], arg[1], **kwarg)
 
 
-class SmallMolLib:
+class SmallMolLib(object):
     """
     Class to manage ligands databases (sdf). Ligands are stored as htmd.smallmol.smallmol.SmallMol objects and
     fields type in the sdf are stored in a list

--- a/htmd/smallmol/tautomers.py
+++ b/htmd/smallmol/tautomers.py
@@ -329,7 +329,7 @@ class TautomerCanonicalizer:
                         score += 150
             # Add SMARTS scores
             for tscore in self.scores:
-                for match in t.GetSubstructMatches(tscore.smarts):
+                for _ in t.GetSubstructMatches(tscore.smarts):
                     logger.debug('Score %+d (%s)', tscore.score, tscore.name)
                     score += tscore.score
             # Add (P,S,Se,Te)-H scores

--- a/htmd/util.py
+++ b/htmd/util.py
@@ -267,7 +267,7 @@ def testDHFR():
 
 
 if __name__ == "__main__":
-    from htmd.ui import *
+    from htmd.molecule.molecule import Molecule
     import doctest
 
     doctest.testmod()

--- a/htmd/vmdgraphics.py
+++ b/htmd/vmdgraphics.py
@@ -70,11 +70,12 @@ class VMDConvexHull(VMDGraphicObject):
 
         Examples
         --------
+        >>> from htmd.vmdgraphics import VMDConvexHull
         >>> m=Molecule("3PTB")
         >>> m.view()
         >>> mf=m.copy()
-        >>> mf.filter("protein ")
-        >>> gh=htmd.vmdgraphics.VMDConvexHull(mf)  # doctest: +ELLIPSIS
+        >>> _ = mf.filter("protein ")
+        >>> gh=VMDConvexHull(mf)  # doctest: +ELLIPSIS
         >>> gh.delete()
         """
 
@@ -280,8 +281,8 @@ class VMDLabels(VMDGraphicObject):
 
         Examples
         --------
-        >>> from htmd.ui import *
-        >>> from htmd.vmdgraphics import *
+        >>> from htmd.ui import *  # doctest: +ELLIPSIS
+        >>> from htmd.vmdgraphics import VMDLabels
         >>> mol = Molecule('3ptb')
         >>> mol.view()
         >>> x = VMDLabels(mol, 'resid 40')
@@ -291,7 +292,6 @@ class VMDLabels(VMDGraphicObject):
         """
         # TODO: After deleting labels it breaks. Better don't delete or fix the code
         super().__init__(None)
-        print(VMDLabels.count)
         idx = mol.atomselect(selection, indexes=True)
         cmd = '''label textsize {s}
 color Labels Atoms {c}
@@ -335,6 +335,6 @@ if __name__ == "__main__":
     ngh=htmd.vmdgraphics.VMDConvexHull(nf,solid=True)
 
     """
-    from htmd.ui import *
+    from htmd.molecule.molecule import Molecule
     import doctest
     doctest.testmod()


### PR DESCRIPTION
Trying to reduce errors in LGTM. Most of them were either from non-object classes or from cyclic imports caused by `from htmd.ui import *` in some `__main__` sections.
Might need another PR later but I wanted to see how many errors this gets rid of :)