### PR TITLE
New small implementation.

### DIFF
--- a/htmd/smallmol/chemlab/periodictable.py
+++ b/htmd/smallmol/chemlab/periodictable.py
@@ -179,3 +179,68 @@ class PeriodicTable:
             atom_data.update({'attachTo': ''})
 
         return atom_data
+
+    def listHybridizations(self):
+        """
+        Lists the Hybridization type available
+
+        """
+
+        dict_hyb = HybridizationType.values
+
+        print("Index  --> Hybridization\n")
+        for i, hyb in dict_hyb.items():
+            print("%5s " % i, '-->', " %-13s" % str(hyb))
+
+    def listBondTypes(self):
+        """
+        Lists the Bonds type available
+
+        """
+
+        dict_bt = BondType.values
+
+        print("Index  --> BondType\n")
+        for i, bt in dict_bt.items():
+            print("%5s " % i, '-->', " %-13s" % str(bt))
+
+
+    def getHybridization(self, index):
+        """
+        Returns the hybridization type from its index value
+
+        Parameters
+        ----------
+        index: int
+            The index representing the hybridization type
+
+        Returns
+        -------
+        hybtype: str
+            The hybridization type
+
+        """
+
+        dict_hyb = HybridizationType.values
+
+        return str(dict_hyb[index])
+
+    def getBondType(self, index):
+        """
+        Returns the bond type from its index value
+
+        Parameters
+        ----------
+        index: int
+            The index representing the bond type
+
+        Returns
+        -------
+        btype: str
+            The bond type
+
+        """
+
+        dict_bt = BondType.values
+
+        return str(dict_bt[index])

--- a/htmd/smallmol/smallmol.py
+++ b/htmd/smallmol/smallmol.py
@@ -9,7 +9,7 @@ import multiprocessing
 import math
 import numpy as np
 from rdkit import Chem
-from htmd.smallmol.util import get_rotationMatrix, rotate, openbabelConvert, _depictMol, depictMultipleMols
+from htmd.smallmol.util import get_rotationMatrix, rotate, openbabelConvert, _depictMol, depictMultipleMols, convertToString
 from htmd.smallmol.chemlab.periodictable import _hybridizations_IdxToType, _bondtypes_IdxToType,  _hybridizations_StringToType, _bondtypes_StringToType
 import logging
 logger = logging.getLogger(__name__)
@@ -160,7 +160,7 @@ class SmallMol(object):
         fields: list
             The list of properties
         """
-        _fields = list(self.mol_fields)
+        _fields = [f for f in list(self.mol_fields) if not f.startswith('_')]
         return _fields
 
     @property
@@ -173,7 +173,7 @@ class SmallMol(object):
         fields: list
             The list of properties
         """
-        _fields = list(self.atom_fields)
+        _fields = [f for f in list(self.atom_fields) if not f.startswith('_')]
         return _fields
 
     @property
@@ -502,7 +502,8 @@ class SmallMol(object):
         array([<rdkit.Chem.rdchem.Atom object at 0x7faf616dd120>,
                <rdkit.Chem.rdchem.Atom object at 0x7faf616dd170>], dtype=object)
         """
-
+        if sel == 'all':
+            sel = 'idx {}'.format(convertToString(self.idx.tolist()))
         # get the field key and the value to grep
         key = sel.split()[0]
         selector = sel.split()[1:]

--- a/htmd/smallmol/smallmol.py
+++ b/htmd/smallmol/smallmol.py
@@ -1805,7 +1805,7 @@ class SmallMolLib(object):
         records = []
         indexes = []
         for i, m in enumerate(self._mols):
-            row = dict((f, m.getProp(f)) for f in fields)
+            row = dict((f, m.__dict__[f]) for f in fields)
             if sketch:
                 mm = deepcopy(m._mol)
                 Compute2DCoords(mm)


### PR DESCRIPTION
Periodic Table:
 - listHybridization and listBondTypes: These will just show the pair index:value. Index is
                                        used from the code; value is chemist readable
 - getHybridization and getBondType: Convert index to value

SmallMol:
 - modified listPropsAtoms and listProp: These will not show anymore properties that starts
                                         with "_".
 - implemented 'all' selection in the "get" method