### PR TITLE
Fixes bug with MDTrajread

### DIFF
--- a/htmd/molecule/readers.py
+++ b/htmd/molecule/readers.py
@@ -1532,6 +1532,12 @@ class TestReaders(TestCase):
         mol = Molecule(os.path.join(home(dataDir='1kdx'), '1kdx_0.pdb'))
         mol.read(os.path.join(home(dataDir='1kdx'), '1kdx.dcd'))
 
+    def test_dcd_into_prmtop(self):
+        from htmd.home import home
+        mol = Molecule(os.path.join(home(dataDir='molecule-readers'), 'dialanine', 'structure.prmtop'))
+        mol.read(os.path.join(home(dataDir='molecule-readers'), 'dialanine', 'traj.dcd'))
+        assert mol.numFrames == 2
+
     def test_dcd_frames(self):
         from htmd.home import home
         mol = Molecule(os.path.join(home(dataDir='1kdx'), '1kdx_0.pdb'))

--- a/htmd/molecule/writers.py
+++ b/htmd/molecule/writers.py
@@ -117,12 +117,20 @@ def checkTruncations(mol):
 
 
 def PDBwrite(mol, filename, frames=None, writebonds=True):
-    if frames is None:
+    if frames is None and mol.numFrames != 0:
         frames = mol.frame
+    else:
+        frames = 0
     frames = ensurelist(frames)
 
     checkTruncations(mol)
-    coords = np.atleast_3d(mol.coords[:, :, frames])
+    if mol.numFrames != 0:
+        coords = np.atleast_3d(mol.coords[:, :, frames])
+        box = mol.box[:, frames[0]]
+    else:  # If Molecule only contains topology, PDB requires some coordinates so give it zeros
+        coords = np.zeros((mol.numAtoms, 3, 1), dtype=np.float32)
+        box = None
+
     numFrames = coords.shape[2]
     nAtoms = coords.shape[0]
 
@@ -139,7 +147,7 @@ def PDBwrite(mol, filename, frames=None, writebonds=True):
             raise RuntimeError('Cannot write PDB beta/temperature with values smaller than -1E5 or larger than 1E6')
 
     fh = open(filename, 'w')
-    box = mol.box[:, frames[0]]
+
     if box is not None and not np.all(mol.box == 0):
         fh.write("CRYST1%9.3f%9.3f%9.3f%7.2f%7.2f%7.2f P 1           1 \n" % (box[0], box[1], box[2], 90, 90, 90))
 


### PR DESCRIPTION
After the PR which doesn't store zero coordinates when loading pure topology files (ala prmtop), the MDtraj reader was crashing. The reason is that the MDTrajRead writes out a PDB file to load the trajectories and the PDB writer was crashing when not finding any frames or coordinates in the molecule.
I now made the PDB writer write out zero coordinates when there are no coordinates in the molecule which fixes the bug. Also added a test for it.
