### PR TITLE
removed version pinning of joblib since they fixed the bug

### DIFF
--- a/package/htmd-deps/DEPENDENCIES
+++ b/package/htmd-deps/DEPENDENCIES
@@ -5,7 +5,7 @@
 python
 pyemma
 natsort
-joblib ==0.11 # TODO: remove 0.11 when joblib is fixed: https://github.com/Acellera/htmd/issues/734; https://github.com/joblib/joblib/issues/643
+joblib
 requests
 scikit-learn
 ipython


### PR DESCRIPTION
@j3mdamas now 0.12.2 is on anaconda as well

Closes https://github.com/Acellera/htmd/issues/734