### PR TITLE
Smallmol get bonds warning

### DIFF
--- a/htmd/smallmol/smallmol.py
+++ b/htmd/smallmol/smallmol.py
@@ -1179,7 +1179,8 @@ class SmallMol(object):
         # checks if coordintates exist
         n_coords = self.getCoords().shape[0]
         if n_coords == 0:
-            raise ValueError('No coordinates found. You need at least one atom coordinate.')
+            raise ValueError('No coordinates found. You need at least one atom coordinate to convert SmallMol'
+                             ' to a Molecule object.')
 
         molHtmd = None
         for n in ids:
@@ -1220,7 +1221,7 @@ class SmallMol(object):
         bondtypes = []
         _mol = self.toRdkitMol()
         for bo in _mol.GetBonds():  # self._mol.GetBonds():
-            bonds.append([bo.GetBeginAtomIdx(), bo.GetEndAtom_Idx()])
+            bonds.append([bo.GetBeginAtomIdx(), bo.GetEndAtomIdx()])
             if bo.GetBondType() == BondType.SINGLE:
                 bondtypes.append('1')
             elif bo.GetBondType() == BondType.DOUBLE:

--- a/htmd/smallmol/smallmol.py
+++ b/htmd/smallmol/smallmol.py
@@ -1176,6 +1176,11 @@ class SmallMol(object):
         elif not isinstance(ids, list):
             raise ValueError('The argument ids should be a list of confomer ids')
 
+        # checks if coordintates exist
+        n_coords = self.getCoords().shape[0]
+        if n_coords == 0:
+            raise ValueError('No coordinates found. You need at least one atom coordinate.')
+
         molHtmd = None
         for n in ids:
             coords = self.getCoords(confId=n)
@@ -1215,7 +1220,7 @@ class SmallMol(object):
         bondtypes = []
         _mol = self.toRdkitMol()
         for bo in _mol.GetBonds():  # self._mol.GetBonds():
-            bonds.append([bo.GetBeginAtomIdx(), bo.GetEndAtomIdx()])
+            bonds.append([bo.GetBeginAtomIdx(), bo.GetEndAtom_Idx()])
             if bo.GetBondType() == BondType.SINGLE:
                 bondtypes.append('1')
             elif bo.GetBondType() == BondType.DOUBLE:
@@ -1224,6 +1229,8 @@ class SmallMol(object):
                 bondtypes.append('3')
             elif bo.GetBondType() == BondType.AROMATIC:
                 bondtypes.append('ar')
+        if len(bonds) == 0:
+            return bonds, bondtypes
         return np.vstack(bonds), np.array(bondtypes)
 
     def depict(self, sketch=True, filename=None, ipython=False, optimize=False, optimizemode='std', removeHs=True,

--- a/htmd/util.py
+++ b/htmd/util.py
@@ -184,7 +184,7 @@ def opm(pdb, keep=False, keepaltloc='A'):
     from htmd.molecule.support import string_to_tempfile
     from htmd.molecule.molecule import Molecule
     # http://opm.phar.umich.edu/pdb/1z98.pdb
-    r = requests.get("http://opm.phar.umich.edu/pdb/{:s}.pdb".format(pdb.lower()))
+    r = requests.get("https://storage.googleapis.com/opm-assets/pdb/{:s}.pdb".format(pdb.lower()))
 
     if r.status_code != 200:
         raise NameError('PDB code not found in the OPM database')


### PR DESCRIPTION
Modified two methods.

1) getBonds that will not crush if no bonds exists in the molecule (eg single atom molecule)
2) toMolecule will raise an error if no atoms coordinates exist