### PR TITLE
Set box size in tleap for CRD files

### DIFF
--- a/htmd/builder/amber.py
+++ b/htmd/builder/amber.py
@@ -386,6 +386,9 @@ def build(mol, ff=None, topo=None, param=None, prefix='structure', outdir='./bui
             f.write('\n')
             mol.remove(torem, _logger=False)
 
+    # Calculate the bounding box and store it in the CRD file
+    f.write('setBox mol "vdw"\n\n')
+
     f.write('# Writing out the results\n')
     f.write('saveamberparm mol ' + prefix + '.prmtop ' + prefix + '.crd\n')
     f.write('quit')
@@ -433,8 +436,11 @@ def build(mol, ff=None, topo=None, param=None, prefix='structure', outdir='./bui
         if os.path.exists(os.path.join(outdir, 'structure.crd')) and \
                         os.path.getsize(os.path.join(outdir, 'structure.crd')) != 0 and \
                         os.path.getsize(os.path.join(outdir, 'structure.prmtop')) != 0:
-            molbuilt = Molecule(os.path.join(outdir, 'structure.prmtop'))
-            molbuilt.read(os.path.join(outdir, 'structure.crd'))
+            try:
+                molbuilt = Molecule(os.path.join(outdir, 'structure.prmtop'))
+                molbuilt.read(os.path.join(outdir, 'structure.crd'))
+            except Exception as e:
+                raise RuntimeError('Failed at reading structure.prmtop/structure.crd due to error: {}'.format(e))
         else:
             raise BuildError('No structure pdb/prmtop file was generated. Check {} for errors in building.'.format(logpath))
 

--- a/htmd/molecule/readers.py
+++ b/htmd/molecule/readers.py
@@ -1181,12 +1181,19 @@ def CRDread(filename, frame=None, topoloc=None):
         if lines[0].startswith('*'):
             raise FormatError('CRDread failed. Trying other readers.')
 
+        natoms = None
+        try:
+            natoms = int(lines[1])
+        except:
+            logger.warning('Didn\'t find number of atoms in CRD file. Will read until the end.')
+
         coords = []
         fieldlen = 12
-        k = 0
         for line in lines[2:]:  # skip first 2 lines
             coords += [float(line[i:i + fieldlen].strip()) for i in range(0, len(line), fieldlen)
                        if len(line[i:i + fieldlen].strip()) != 0]
+            if natoms is not None and len(coords) == natoms*3:
+                break
 
     coords = np.vstack([coords[i:i + 3] for i in range(0, len(coords), 3)])[:, :, np.newaxis]
     return MolFactory.construct(None, Trajectory(coords=coords), filename, frame)


### PR DESCRIPTION
Added the command to set the box size.
As a consequence I found out we did not read correctly CRD files when they include box sizes at the end and fixed that bug.
Had to update all test files since tleap moves all coordinates to the positive domain when setting a box size. Also for some reason the tleap log now suddenly prints out the PDB resid instead of it's internal resid. Weird stuff but it seems to work correctly.

Closes https://github.com/Acellera/htmd/issues/762