### PR TITLE
improved ensurelist to support ranges

### DIFF
--- a/htmd/util.py
+++ b/htmd/util.py
@@ -44,6 +44,8 @@ def ensurelist(tocheck, tomod=None):
         tomod = tocheck
     if isinstance(tocheck, np.ndarray):
         return list(tomod)
+    if isinstance(tocheck, range):
+        return list(tocheck)
     if not isinstance(tocheck, list) and not isinstance(tocheck, tuple):
         return [tomod, ]
     return tomod


### PR DESCRIPTION
Fixes a bug where passing a `range` (not `np.arange`) to `ensurelist` returned a list with the range inside instead of a list of the elements of the range.