### PR TITLE
Fftype fixing

### DIFF
--- a/htmd/builder/amber.py
+++ b/htmd/builder/amber.py
@@ -864,7 +864,7 @@ class TestAmberBuild(unittest.TestCase):
 
     def testProteinLigand(self):
         from htmd.builder.solvate import solvate
-        from htmd.parameterization.fftype import fftype, FFTypeMethod
+        from htmd.parameterization.fftype import fftype
         from htmd.parameterization.writers import writeFRCMOD
 
         # Test protein ligand building with parametrized ligand
@@ -874,7 +874,7 @@ class TestAmberBuild(unittest.TestCase):
 
         mol = Molecule(join(refdir, '3ptb_mod.pdb'))
         lig = Molecule(join(refdir, 'benzamidine.pdb'), guess=('bonds', 'angles', 'dihedrals'))
-        prm, lig = fftype(lig, method=FFTypeMethod.GAFF2)
+        prm, lig = fftype(lig, method='GAFF2')
         writeFRCMOD(lig, prm, join(tmpdir, 'mol.frcmod'))
         lig.segid[:] = 'L'
 

--- a/htmd/parameterization/detect.py
+++ b/htmd/parameterization/detect.py
@@ -22,7 +22,7 @@ def _getMolecularGraph(molecule):
 
     graph = nx.Graph()
     for i, element in enumerate(molecule.element):
-        graph.add_node(i, element=element, number=elements.symbol(element).number)
+        graph.add_node(i, element=element, number=elements.symbol(element.capitalize()).number)
     graph.add_edges_from(molecule.bonds)
 
     return graph

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -8,43 +8,45 @@ import shutil
 import subprocess
 import os
 from tempfile import TemporaryDirectory
-from htmd.parameterization.readers import readPREPI, readRTF
-from enum import Enum
+from htmd.parameterization.readers import readPREPI, readFRCMOD, readRTF
 import numpy as np
 import parmed
 import logging
+import unittest
 
 logger = logging.getLogger(__name__)
 
 
-class FFTypeMethod(Enum):
-    NONE = 0
-    CHARMM = 1
-    AMBER = 2
-    CGenFF_2b6 = 1000
-    GAFF = 1001
-    GAFF2 = 1002
+fftypemethods = ('CGenFF_2b6', 'GAFF', 'GAFF2')
 
 
-def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCharges=None, tmpDir=None, netcharge=None):
+def listFftypemethods():
+    print('\n'.join(fftypemethods))
+    return
+
+
+def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpDir=None, netcharge=None):
     """
     Function to assign atom types and force field parameters for a given molecule.
 
-    The assigment can be done:
-      1. For CHARMM CGenFF_2b6 with MATCH (method = FFTypeMethod.CGenFF_2b6);
-      2. For AMBER GAFF with antechamber (method = FFTypeMethod.GAFF);
-      3. For AMBER GAFF2 with antechamber (method = FFTypeMethod.GAFF2);
+    The assignment can be done:
+      1. For CHARMM CGenFF_2b6 with MATCH (method = 'CGenFF_2b6');
+      2. For AMBER GAFF with antechamber (method = 'GAFF');
+      3. For AMBER GAFF2 with antechamber (method = 'GAFF2');
 
     Parameters
     ----------
-    mol : FFMolecule
-        Molecule to use for the assigment
+    mol : Molecule
+        Molecule to use for the assignment
     rtfFile : str
         Path to a RTF file from which to read the topology
     prmFile : str
         Path to a PRM file from which to read the parameters
-    method : FFTypeMethod
-        Assigment method
+    method : str
+        Atomtyping assignment method.
+        Use :func:`fftype.listFftypemethods <htmd.parameterization.fftype.listFftypemethods>` to get a list of available
+        methods.
+        Default: :func:`fftype.defaultFftypemethod <htmd.parameterization.fftype.defaultFftypemethod>`
     acCharges : str
         Optionally assign charges with antechamber. Check `antechamber -L` for available options. Caution: This will
         overwrite any charges defined in the mol2 file.
@@ -56,53 +58,60 @@ def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCh
 
     Returns
     -------
-    prm : :class:`ParameterSet<parmed.parameters.ParameterSet>` object
+    prm : :class:`ParameterSet <parmed.parameters.ParameterSet>` object
         Returns a parmed ParameterSet object with the parameters.
     mol : :class:`Molecule <htmd.molecule.molecule.Molecule>` object
         The modified Molecule object with the matching atom types for the ParameterSet
     """
+
+    if method not in fftypemethods:
+        raise ValueError('Invalid method {}. Available methods {}'.format(method, ','.join(fftypemethods)))
+
     if netcharge is None:
+        logger.info('Using atomic charges from molecule object to calculate net charge')
         netcharge = np.sum(mol.charge)
     netcharge = int(round(netcharge))
 
+    prm = names = elements = atomtypes = charges = impropers = masses = None
     if rtfFile and prmFile:
         logger.info('Reading FF parameters from {} and {}'.format(rtfFile, prmFile))
         prm = parmed.charmm.CharmmParameterSet(rtfFile, prmFile)
         names, elements, atomtypes, charges, masses, impropers = readRTF(rtfFile)
         # addParmedResidue(prm, names, elements, atomtypes, charges, impropers)
     else:
-        logger.info('Assigned atom types with {}'.format(method.name))
+        logger.info('Assigning atom types with {}'.format(method))
         # Find the executables
-        if method == FFTypeMethod.GAFF or method == FFTypeMethod.GAFF2:
-            antechamber_binary = shutil.which("antechamber")
+        antechamber_binary = None
+        parmchk2_binary = None
+        match_binary = None
+        if method in ('GAFF', 'GAFF2'):
+            antechamber_binary = shutil.which('antechamber')
             if not antechamber_binary:
-                raise RuntimeError("antechamber executable not found")
-            parmchk2_binary = shutil.which("parmchk2")
+                raise RuntimeError('antechamber executable not found')
+            parmchk2_binary = shutil.which('parmchk2')
             if not parmchk2_binary:
-                raise RuntimeError("parmchk2 executable not found")
-        elif method == FFTypeMethod.CGenFF_2b6:
-            match_binary = shutil.which("match-typer")
+                raise RuntimeError('parmchk2 executable not found')
+        elif method == 'CGenFF_2b6':
+            match_binary = shutil.which('match-typer')
             if not match_binary:
-                raise RuntimeError("match-typer executable not found")
+                raise RuntimeError('match-typer executable not found')
         else:
-            raise ValueError('method')
+            raise ValueError('method {} is not implemented'.format(method))
 
         # Create a temporary directory
         with TemporaryDirectory() as tmpdir:
             # HACK to keep the files
             tmpdir = tmpdir if tmpDir is None else tmpDir
 
-            if method == FFTypeMethod.GAFF or method == FFTypeMethod.GAFF2:
+            if method in ('GAFF', 'GAFF2'):
+                from htmd.molecule.molecule import Molecule
                 # Write the molecule to a file
                 mol.write(os.path.join(tmpdir, 'mol.mol2'))
 
                 # Run antechamber
-                if method == FFTypeMethod.GAFF:
-                    atomtype = "gaff"
-                elif method == FFTypeMethod.GAFF2:
-                    atomtype = "gaff2"
-                else:
-                    raise ValueError('method')
+
+                atomtype = method.lower()
+
                 cmd = [antechamber_binary,
                        '-at', atomtype,
                        '-nc', str(netcharge),
@@ -119,17 +128,29 @@ def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCh
                 # Run parmchk2
                 returncode = subprocess.call([parmchk2_binary,
                                               '-f', 'prepi',
+                                              '-s', atomtype,
                                               '-i', 'mol.prepi',
                                               '-o', 'mol.frcmod',
                                               '-a', 'Y'], cwd=tmpdir)
                 if returncode != 0:
                     raise RuntimeError('"parmchk2" failed')
 
+                # Check if antechamber did changes in atom names (and suggest the user to fix the names)
+                acmol = Molecule(os.path.join(tmpdir, 'NEWPDB.PDB'), type='pdb')
+                acmol.name = np.array([n.upper() for n in acmol.name]).astype(np.object)
+                if len(np.setdiff1d(mol.name, acmol.name)) != 0 or len(np.setdiff1d(acmol.name, mol.name)) != 0:
+                    raise RuntimeError('Initial atom names {} were changed by antechamber to {}. This probably means '
+                                       'that the start of the atom name does not match element symbol. Please check '
+                                       'the molecule.'.format(','.join(np.setdiff1d(mol.name, acmol.name)),
+                                                              ','.join(np.setdiff1d(acmol.name, mol.name))
+                                                              )
+                                       )
+
                 # Read the results
                 prm = parmed.amber.AmberParameterSet(os.path.join(tmpdir, 'mol.frcmod'))
-                names, elements, atomtypes, charges, masses, impropers = readPREPI(mol, os.path.join(tmpdir, 'mol.prepi'))
-                # addParmedResidue(prm, names, elements, atomtypes, charges, impropers)
-            elif method == FFTypeMethod.CGenFF_2b6:
+                names, atomtypes, charges, impropers = readPREPI(mol, os.path.join(tmpdir, 'mol.prepi'))
+                masses, elements = readFRCMOD(atomtypes, os.path.join(tmpdir, 'mol.frcmod'))
+            elif method == 'CGenFF_2b6':
 
                 # Write the molecule to a file
                 mol.write(os.path.join(tmpdir, 'mol.pdb'))
@@ -146,7 +167,7 @@ def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCh
                 names, elements, atomtypes, charges, masses, impropers = readRTF(os.path.join(tmpdir, 'mol.rtf'))
                 # addParmedResidue(prm, names, elements, atomtypes, charges, impropers)
             else:
-                raise ValueError('Invalide method {}'.format(method))
+                raise ValueError('Invalid method {}'.format(method))
 
     # Substituting values from the read-in topology
     mol = mol.copy()
@@ -161,13 +182,155 @@ def fftype(mol, rtfFile=None, prmFile=None, method=FFTypeMethod.CGenFF_2b6, acCh
     return prm, mol
 
 
+class TestFftype(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestFftype, self).__init__(*args, **kwargs)
+        from htmd.home import home
+        from htmd.molecule.molecule import Molecule
+        from htmd.parameterization.util import canonicalizeAtomNames, getEquivalentsAndDihedrals
+        from yaml import load as yamlload
+        from pickle import load as pickleload
+        self.refDir = home(dataDir='test-fftype')
+        self.Molecule = Molecule
+        self.canonicalizeAtomNames = canonicalizeAtomNames
+        self.getEquivalentsAndDihedrals = getEquivalentsAndDihedrals
+        self.yamlload = yamlload
+        self.pickleload = pickleload
+
+    def assertListAlmostEqual(self, list1, list2, places=7):
+        self.assertEqual(len(list1), len(list2))
+        for a, b in zip(list1, list2):
+            self.assertAlmostEqual(a, b, places=places)
+
+    def setUp(self):
+        pass
+
+    def _init_mol(self, molName, ffTypeMethod, chargetuple):
+        molFile = os.path.join(self.refDir, '{}.mol2'.format(molName))
+        if chargetuple == 'None':
+            acCharges = None
+            netcharge = None
+        else:
+            acCharges = chargetuple[0]
+            netcharge = chargetuple[1]
+
+        testMolecule = self.Molecule(molFile)
+        testMolecule = self.canonicalizeAtomNames(testMolecule, ffTypeMethod)
+        testMolecule, _, _ = self.getEquivalentsAndDihedrals(testMolecule)
+
+        from tempfile import mkdtemp
+        tmpDir = mkdtemp(suffix='fftype')
+        testParameters, testMolecule = fftype(testMolecule,
+                                              method=ffTypeMethod,
+                                              acCharges=acCharges,
+                                              netcharge=netcharge,
+                                              tmpDir=tmpDir)
+        testIntermediaryFiles = sorted(os.listdir(tmpDir))
+
+        self.testMolecule = testMolecule
+        self.testParameters = testParameters
+        self.testIntermediaryFiles = testIntermediaryFiles
+
+    def _generate_references(self, name, method):
+        import numbers
+        import numpy
+        from pickle import dump as pickledump
+
+        def mapping(value):
+            if isinstance(value, str):
+                return '\'{}\''.format(value)
+            elif isinstance(value, numbers.Real) or isinstance(value, numbers.Integral):
+                return str(value)
+            elif isinstance(value, numpy.ndarray):
+                return '[{}]'.format(', '.join(map(mapping, list(value))))
+            else:
+                raise Exception('No mapping for type {}'.format(type(value)))
+
+        print('Copy these to mol_props.yaml')
+        for prop in ['name', 'element', 'atomtype', 'charge', 'impropers']:
+            print('{}: {}'.format(prop if prop.endswith('s') else '{}s'.format(prop),
+                                  '[{}]'.format(', '.join(map(mapping, getattr(self.testMolecule, prop))))))
+        print('\nVerify these. They are already written through pickle')
+        with open(os.path.join(self.refDir, name, method, 'params.p'), 'wb') as outfile:
+            for i in self.testParameters.__dict__:
+                print(i, getattr(self.testParameters, i))
+            pickledump(self.testParameters, outfile)
+
+        print('\nCopy these to intermediary_files.yaml')
+        print('[{}]'.format(', '.join('\'{}\''.format(i) for i in self.testIntermediaryFiles)))
+
+    def _test_mol_props(self, names, elements, atomtypes, charges, impropers):
+        self.assertEqual(list(self.testMolecule.name), names)
+        self.assertEqual(list(self.testMolecule.element), elements)
+        self.assertEqual(list(self.testMolecule.atomtype), atomtypes)
+        self.assertListAlmostEqual(list(self.testMolecule.charge), charges)
+        if len(impropers) != 0:
+            for test, ref in zip(list(self.testMolecule.impropers), impropers):
+                self.assertEqual(list(test), ref)
+        else:
+            self.assertEqual(list(self.testMolecule.impropers), impropers)
+
+    def _test_params(self, params):
+        for i in self.testParameters.__dict__:
+            self.assertEqual(getattr(self.testParameters, i), getattr(params, i))
+
+    def _test_intermediary_files(self, files):
+        self.assertEqual(self.testIntermediaryFiles, files)
+
+    def test_mol(self):
+
+        toTest = (
+            ('ethanolamine', 'GAFF2', 'None'),
+            ('1o5b_ligand', 'GAFF2', ('gas', 1)),
+            ('1z95_ligand', 'GAFF2', ('gas', 0)),
+            ('4gr0_ligand', 'GAFF2', ('gas', -1))
+        )
+
+        for name, method, chargetuple in toTest:
+            with self.subTest(name=name, method=method, chargetuple=chargetuple):
+                refDir = os.path.join(self.refDir, name, method)
+                self._init_mol(name, method, chargetuple)
+                # self._generate_references(name, method)
+                with open(os.path.join(refDir, 'mol_props.yaml'), 'r') as infile:
+                    refProps = self.yamlload(infile)
+                self._test_mol_props(**refProps)
+                with open(os.path.join(refDir, 'params.p'), 'rb') as infile:
+                    refParams = self.pickleload(infile)
+                self._test_params(refParams)
+                with open(os.path.join(refDir, 'intermediary_files.yaml'), 'r') as infile:
+                    refFiles = self.yamlload(infile)
+                self._test_intermediary_files(refFiles)
+
+    def test_broken_atomname(self):
+        molFile = os.path.join(self.refDir, '{}.mol2'.format('ethanolamine_wrongnames'))
+
+        testMolecule = self.Molecule(molFile)
+        testMolecule = self.canonicalizeAtomNames(testMolecule, 'GAFF2')
+        testMolecule, _, _ = self.getEquivalentsAndDihedrals(testMolecule)
+
+        from tempfile import mkdtemp
+        tmpDir = mkdtemp(suffix='fftype')
+        with self.assertRaises(RuntimeError):
+            _, _ = fftype(testMolecule,
+                          method='GAFF2',
+                          acCharges=None,
+                          netcharge=None,
+                          tmpDir=tmpDir)
+
+
 if __name__ == '__main__':
+
+    import sys
+
+    unittest.main(verbosity=2)
+    sys.exit(0)
 
     import sys
     import re
     from htmd.home import home
     from htmd.molecule.molecule import Molecule
-    from htmd.parameterization.writers import writeRTF, writePRM, writeFRCMOD
+    from htmd.parameterization.writers import writeRTF, writePRM
     from htmd.parameterization.util import canonicalizeAtomNames, getEquivalentsAndDihedrals
 
     # BUG: MATCH does not work on Mac!
@@ -178,20 +341,14 @@ if __name__ == '__main__':
     molFile = os.path.join(home('building-protein-ligand'), 'benzamidine.mol2')
     refDir = home(dataDir='test-fftype/benzamidine')
     mol = Molecule(molFile)
-    mol = canonicalizeAtomNames(mol)
-    mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
     with TemporaryDirectory() as tmpDir:
 
-        parameters, mol = fftype(mol, method=FFTypeMethod.CGenFF_2b6)
+        mol = canonicalizeAtomNames(mol, 'CGenFF_2b6')
+        mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
+        parameters, mol = fftype(mol, method='CGenFF_2b6')
         writeRTF(mol, parameters, 0, os.path.join(tmpDir, 'cgenff.rtf'))
         writePRM(mol, parameters, os.path.join(tmpDir, 'cgenff.prm'))
-
-        parameters, mol = fftype(mol, method=FFTypeMethod.GAFF)
-        writeFRCMOD(mol, parameters, os.path.join(tmpDir, 'gaff.frcmod'))
-
-        parameters, mol = fftype(mol, method=FFTypeMethod.GAFF2)
-        writeFRCMOD(mol, parameters, os.path.join(tmpDir, 'gaff2.frcmod'))
 
         for testFile in os.listdir(refDir):
             print(testFile)
@@ -206,11 +363,3 @@ if __name__ == '__main__':
     with TemporaryDirectory() as tmpDir:
         parameters, mol = fftype(mol, method=FFTypeMethod.CGenFF_2b6, tmpDir=tmpDir)
         assert sorted(os.listdir(tmpDir)) == ['mol.pdb', 'mol.prm', 'mol.rtf', 'top_mol.rtf']
-
-    with TemporaryDirectory() as tmpDir:
-        parameters, mol = fftype(mol, method=FFTypeMethod.GAFF2, tmpDir=tmpDir)
-        assert sorted(os.listdir(tmpDir)) == ['ANTECHAMBER.FRCMOD', 'ANTECHAMBER_AC.AC', 'ANTECHAMBER_AC.AC0',
-                                              'ANTECHAMBER_BOND_TYPE.AC', 'ANTECHAMBER_BOND_TYPE.AC0',
-                                              'ANTECHAMBER_PREP.AC', 'ANTECHAMBER_PREP.AC0', 'ATOMTYPE.INF',
-                                              'NEWPDB.PDB', 'PREP.INF', 'mol.frcmod', 'mol.mol2', 'mol.prepi']
-

--- a/htmd/parameterization/parameterset.py
+++ b/htmd/parameterization/parameterset.py
@@ -154,15 +154,15 @@ class Test(unittest.TestCase):
 
     def setUp(self):
         from htmd.home import home
-        from htmd.parameterization.fftype import FFTypeMethod, fftype
+        from htmd.parameterization.fftype import fftype
         from htmd.parameterization.util import canonicalizeAtomNames, getEquivalentsAndDihedrals
         from htmd.molecule.molecule import Molecule
 
         molFile = os.path.join(home('test-param'), 'glycol.mol2')
         mol = Molecule(molFile)
-        mol = canonicalizeAtomNames(mol)
+        mol = canonicalizeAtomNames(mol, 'GAFF2')
         mol, self.equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
-        _, mol = fftype(mol, method=FFTypeMethod.GAFF2)
+        _, mol = fftype(mol, method='GAFF2')
         self.mol = mol
 
     def test_getEquivalentDihedrals(self):

--- a/htmd/parameterization/util.py
+++ b/htmd/parameterization/util.py
@@ -24,7 +24,7 @@ def getEquivalentsAndDihedrals(mol):
     return mol, equivalents, all_dihedrals
 
 
-def canonicalizeAtomNames(mol, inplace=False, _logger=True):
+def canonicalizeAtomNames(mol, fftypemethod, inplace=False, _logger=True):
     """
     This fixes up the atom naming and reside name to be consistent.
     NB this scheme matches what MATCH does.
@@ -41,7 +41,7 @@ def canonicalizeAtomNames(mol, inplace=False, _logger=True):
 
     sufices = {}
     for i in range(mol.numAtoms):
-        name = guessElementFromName(mol.name[i]).upper()
+        name = createElementForFftype(i, mol, fftypemethod).upper()
 
         sufices[name] = sufices.get(name, 0) + 1
         name += str(sufices[name])
@@ -54,38 +54,79 @@ def canonicalizeAtomNames(mol, inplace=False, _logger=True):
         return mol
 
 
-def guessElementFromName(name):
-    '''
+def createElementForFftype(index, mol, fftypemethod):
+    """
     Guess element from an atom name
 
-    >>> from htmd.parameterization.util import guessElementFromName
-    >>> guessElementFromName('C')
+    >>> from htmd.parameterization.util import createElementForFftype
+    >>> createElementForFftype('C')
     'C'
-    >>> guessElementFromName('C1')
+    >>> createElementForFftype('C1')
     'C'
-    >>> guessElementFromName('C42')
+    >>> createElementForFftype('C42')
     'C'
-    >>> guessElementFromName('C7S')
+    >>> createElementForFftype('C7S')
     'C'
-    >>> guessElementFromName('HN1')
+    >>> createElementForFftype('HN1')
     'H'
-    >>> guessElementFromName('CL')
+    >>> createElementForFftype('CL')
     'Cl'
-    >>> guessElementFromName('CA1')
+    >>> createElementForFftype('CA1')
     'Ca'
-    '''
-    import periodictable
-    symbol = name.capitalize()
+    """
 
-    while symbol:
-        try:
-            element = periodictable.elements.symbol(symbol)
-        except ValueError:
-            symbol = symbol[:-1]
+    from htmd.parameterization.fftype import fftypemethods
+
+    elements = dict()
+    elements['GAFF'] = ['H', 'O', 'C', 'N', 'S', 'P', 'F', 'Cl', 'Br', 'I']
+    elements['GAFF2'] = ['H', 'O', 'C', 'N', 'S', 'P', 'F', 'Cl', 'Br', 'I']
+
+    if fftypemethod == 'CGenFF_2b6':
+        import periodictable
+        name = mol.name[index]
+        symbol = name.capitalize()
+
+        while symbol:
+            try:
+                element = periodictable.elements.symbol(symbol)
+            except ValueError:
+                symbol = symbol[:-1]
+            else:
+                return element.symbol
+
+        raise ValueError('Cannot guess element from atom name: {}'.format(name))
+    elif fftypemethod in ('GAFF2', 'GAFF'):
+        name = mol.name[index]
+        scan = {'matches': 0, 'elements': []}
+        for e in elements[fftypemethod]:
+            if name.capitalize().startswith(e):
+                scan['matches'] += 1
+                scan['elements'].append(e)
+
+        if scan['matches'] == 1:
+            return scan['elements'][0]
+        elif scan['matches'] > 1:
+            # Should only happen with atom names starting with CL
+            import networkx as nx
+
+            # Guess bonds if not present
+            if len(mol.bonds) == 0:
+                logger.warning('No bonds found! Guessing them...')
+                mol.bonds = mol._guessBonds()
+
+            g = nx.Graph()
+            g.add_edges_from(mol.bonds)
+
+            if len(g[index]) == 1:
+                return 'Cl'
+            else:
+                return 'C'
         else:
-            return element.symbol
-
-    raise ValueError('Cannot guess element from atom name: {}'.format(name))
+            raise ValueError('Cannot create element from atom name: {}. It probably does not match the atom elements'
+                             'available for {}: {}'.format(name, fftypemethod, elements[fftypemethod]))
+    else:
+        raise RuntimeError('Not a valid fftypemethod: {}. Valid methods: {}'.format(fftypemethod,
+                                                                                    ','.join(fftypemethods)))
 
 
 def centreOfMass(mol):
@@ -251,7 +292,7 @@ def fitDihedrals(mol, qm, method, prm, all_dihedrals, dihedrals, outdir, geomopt
         qm.optimize = geomopt
         qm.restrained_dihedrals = np.array([dihedral])
         qm.directory = directory
-        qm.setup() # QM object is reused, so it has to be properly set up before retrieving.
+        qm.setup()  # QM object is reused, so it has to be properly set up before retrieving.
         qm_results.append(qm.retrieve())
 
     # Fit the dihedral parameters
@@ -262,7 +303,7 @@ def fitDihedrals(mol, qm, method, prm, all_dihedrals, dihedrals, outdir, geomopt
     df.molecule = mol
     df.dihedrals = dihedrals
     df.qm_results = qm_results
-    df.result_directory = os.path.join(outdir, 'parameters', method.name, _qm_method_name(qm), 'plots')
+    df.result_directory = os.path.join(outdir, 'parameters', method, _qm_method_name(qm), 'plots')
 
     # In case of FakeQM, the initial parameters are set to zeros.
     # It prevents DihedralFitting class from cheating :D

--- a/htmd/parameterization/writers.py
+++ b/htmd/parameterization/writers.py
@@ -1,6 +1,5 @@
 from htmd.parameterization.util import _qm_method_name
 from htmd.parameterization.parameterset import getImproperParameter, getParameter
-from htmd.parameterization.fftype import FFTypeMethod
 import os
 import parmed
 import numpy as np
@@ -227,7 +226,7 @@ def writeParameters(mol, parameters, qm, method, netcharge, outdir, original_coo
     typemap = None
     extensions = ('mol2', 'pdb', 'coor')
 
-    if method == FFTypeMethod.CGenFF_2b6:
+    if method == 'CGenFF_2b6':
         extensions += ('psf', 'rtf', 'prm')
 
         # TODO: remove?
@@ -254,7 +253,7 @@ run 0'''
         print(tmp, file=f)
         f.close()
 
-    elif method in (FFTypeMethod.GAFF, FFTypeMethod.GAFF2):
+    elif method in ('GAFF', 'GAFF2'):
         # types need to be remapped because Amber FRCMOD format limits the type to characters
         # writeFrcmod does this on the fly and returns a mapping that needs to be applied to the mol
         # TODO: get rid of this mapping

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -34,7 +34,7 @@ class FakeQM(QMBase):
     >>> from tempfile import TemporaryDirectory
     >>> from htmd.home import home
     >>> from htmd.numbautil import dihedralAngle
-    >>> from htmd.parameterization.fftype import fftype, FFTypeMethod
+    >>> from htmd.parameterization.fftype import fftype
     >>> from htmd.parameterization.util import getEquivalentsAndDihedrals, canonicalizeAtomNames
     >>> from htmd.molecule.molecule import Molecule
     >>> from htmd.qm.fake import FakeQM
@@ -43,7 +43,7 @@ class FakeQM(QMBase):
     >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
     >>> mol = Molecule(molFile)
     >>> mol = canonicalizeAtomNames(mol)
-    >>> parameters, mol = fftype(mol, method=FFTypeMethod.GAFF2)
+    >>> parameters, mol = fftype(mol, method='GAFF2')
     >>> mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
     Run a single-point energy and ESP calculation
@@ -183,7 +183,7 @@ class FakeQM2(FakeQM):
     >>> from tempfile import TemporaryDirectory
     >>> from htmd.home import home
     >>> from htmd.numbautil import dihedralAngle
-    >>> from htmd.parameterization.fftype import fftype, FFTypeMethod
+    >>> from htmd.parameterization.fftype import fftype
     >>> from htmd.parameterization.util import canonicalizeAtomNames
     >>> from htmd.molecule.molecule import Molecule
     >>> from htmd.qm.fake import FakeQM2
@@ -192,7 +192,7 @@ class FakeQM2(FakeQM):
     >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
     >>> mol = Molecule(molFile, guessNE='bonds', guess=('angles', 'dihedrals'))
     >>> mol = canonicalizeAtomNames(mol)
-    >>> parameters, mol = fftype(mol, method=FFTypeMethod.GAFF2)
+    >>> parameters, mol = fftype(mol, method='GAFF2')
 
     Run a single-point energy and ESP calculation
     >>> with TemporaryDirectory() as tmpDir:
@@ -248,7 +248,6 @@ class FakeQM2(FakeQM):
 
     def _get_prmtop(self):
         from htmd.parameterization.writers import writeFRCMOD, getAtomTypeMapping
-        from htmd.parameterization.fftype import FFTypeMethod
 
         with TemporaryDirectory() as tmpDir:
             frcFile = os.path.join(tmpDir, 'mol.frcmod')


### PR DESCRIPTION
This is an incomplete PR as per @raimis request. I'll add a comment for when's it's ready. It's basically needing htmd-data changes (a lot).

Resume of changes:
- parmchk2 now does GAFF2
- elements are now guessed by which masses were assigned during fftype
- unittests added to fftype, which include: ethanolamine, three more
  molecules that have all elements recognizable in GAFF(2)
- get ride of Enum in FFTypeMethods (and fixing code accordingly)
- new data to match the changes (still incomplete)

This will fail CI while I do not fix the data.

List of currently failing files:
```
AssertionError: Tests failed for the following files:
/shared/joao/test_parameterize/htmd/htmd/builder/amber.py
/shared/joao/test_parameterize/htmd/htmd/parameterization/esp.py
/shared/joao/test_parameterize/htmd/htmd/parameterization/test.py
/shared/joao/test_parameterize/htmd/htmd/qm/test.py
/shared/joao/test_parameterize/htmd/htmd/qm/psi4.py
/shared/joao/test_parameterize/htmd/htmd/qm/fake.py
```

All make sense. `amber.py` fails because benzamidine was changed to GAFF2 and now the prmtop (the parameters) is obviously different.