### PR TITLE
Fix PRM writer for CGENFF

### DIFF
--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -111,7 +111,8 @@ def printReport(mol, netcharge, equivalents, all_dihedrals):
 
     print('Equivalent atom groups:')
     for atom_group in equivalents[0]:
-        print('  ' + ', '.join(mol.name[list(atom_group)]))
+        if len(atom_group) > 1:
+            print('  ' + ', '.join(mol.name[list(atom_group)]))
 
     print('Parameterizable dihedral angles:')
     for equivalent_dihedrals in all_dihedrals:

--- a/htmd/parameterization/writers.py
+++ b/htmd/parameterization/writers.py
@@ -151,19 +151,19 @@ def writePRM(mol, parameters, filename):
     print("BONDS", file=f)
     types = getSortedAndUniqueTypes(mol.atomtype[mol.bonds], 'bond_types')
     for type in types:
-        val = parameters.bond_types[type]
+        val = getParameter(type, parameters.bond_types)
         print("%-6s %-6s %8.2f %8.4f" % (type[0], type[1], val.k, val.req), file=f)
 
     print("\nANGLES", file=f)
     types = getSortedAndUniqueTypes(mol.atomtype[mol.angles], 'angle_types')
     for type in types:
-        val = parameters.angle_types[type]
+        val = getParameter(type, parameters.angle_types)
         print("%-6s %-6s %-6s %8.2f %8.2f" % (type[0], type[1], type[2], val.k, val.theteq), file=f)
 
     print("\nDIHEDRALS", file=f)
     types = getSortedAndUniqueTypes(mol.atomtype[mol.dihedrals], 'dihedral_types')
     for type in types:
-        val = parameters.dihedral_types[type]
+        val = getParameter(type, parameters.dihedral_types)
         for term in val:
             print("%-6s %-6s %-6s %-6s %12.8f %d %12.8f" % (type[0], type[1], type[2], type[3], term.phi_k, term.per, term.phase), file=f)
 


### PR DESCRIPTION
Closes #754  #776 

It was an issue where I didn't update the PRM writer when I made the `getParameters` function for the new parmed versions and it went unnoticed.

Since I was making changes I also made parameterize only print equivalents when they exist, instead of printing a list of all atoms of the molecule which is useless.