### PR TITLE
Fix molecule and atom renaming

### DIFF
--- a/htmd/charge/esp.py
+++ b/htmd/charge/esp.py
@@ -221,7 +221,7 @@ class ESP:
     def _compute_constraint(self, group_charges, _):
 
         charges = self._map_groups_to_atoms(group_charges)
-        constraint = np.sum(charges) - int(np.round(self.molecule.charge.sum()))
+        constraint = np.sum(charges) - self._charge
 
         return constraint
 
@@ -273,13 +273,11 @@ class ESP:
         """
         logger.info('Start charge optimization')
 
-        equivalents = detectEquivalentAtoms(self.molecule)
+        self._charge = self.qm_results[0].charge
 
+        equivalents = detectEquivalentAtoms(self.molecule)
         self._equivalent_atom_groups = equivalents[0]
         self._equivalent_group_by_atom = equivalents[2]
-
-        for result in self.qm_results:
-            assert int(np.round(self.molecule.charge.sum())) == result.charge
 
         # Get charge bounds
         lower_bounds, upper_bounds = self._get_bounds()

--- a/htmd/charge/esp.py
+++ b/htmd/charge/esp.py
@@ -200,6 +200,8 @@ class ESP:
         self.qm_results = None
         self.fixed = []
 
+        self._charge = 0
+
         self._reciprocal_distances = None
 
         self._equivalent_atom_groups = None

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -71,16 +71,23 @@ def _get_molecule(args):
 
     mol = Molecule(args.filename)
 
+    # Check if the file contain just one conformation
     if mol.numFrames != 1:
         raise RuntimeError('{} has to contain only one molecule, but found {}'.format(args.filename, mol.numFrames))
 
+    # Check if each atom name is unique
     if np.unique(mol.name).size != mol.numAtoms:
         raise RuntimeError('The atom names in {} has to be unique!'.format(args.filename))
 
+    # Guess elements
+    # TODO: it should not depend on FF
     mol = guessElements(mol, args.forcefield[0])
 
     # Set segment ID
+    # Note: it is need to write complete PDB files
     mol.segid[:] = 'L'
+
+    # TODO: check charge
 
     # TODO: check bonds
 
@@ -258,8 +265,7 @@ def main_parameterize(arguments=None):
 
     # Start processing
     from htmd.parameterization.fftype import fftype
-    from htmd.parameterization.util import getEquivalentsAndDihedrals, minimize, \
-        fitDihedrals, _qm_method_name
+    from htmd.parameterization.util import getEquivalentsAndDihedrals, minimize, fitDihedrals, _qm_method_name
     from htmd.parameterization.parameterset import recreateParameters, createMultitermDihedralTypes, inventAtomTypes
     from htmd.parameterization.writers import writeParameters
 
@@ -313,8 +319,6 @@ def main_parameterize(arguments=None):
 
     print('\n === Parameterizing %s ===\n' % args.filename)
     for method in args.forcefield:
-
-        mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
         print(" === Fitting for %s ===\n" % method)
         printReport(mol, args.charge, equivalents, all_dihedrals)

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -10,7 +10,7 @@ import logging
 import numpy as np
 
 from htmd.version import version
-from htmd.parameterization.fftype import fftypemethods
+from htmd.parameterization.fftype import fftypemethods, _canonicalizeAtomNames
 
 logger = logging.getLogger(__name__)
 
@@ -255,13 +255,13 @@ def main_parameterize(arguments=None):
 
     # Start processing
     from htmd.parameterization.fftype import fftype
-    from htmd.parameterization.util import getEquivalentsAndDihedrals, canonicalizeAtomNames, minimize, \
+    from htmd.parameterization.util import getEquivalentsAndDihedrals, minimize, \
         fitDihedrals, _qm_method_name
     from htmd.parameterization.parameterset import recreateParameters, createMultitermDihedralTypes, inventAtomTypes
     from htmd.parameterization.writers import writeParameters
 
     # Get molecule with default atomtyping just for initial processing
-    mol = canonicalizeAtomNames(mol, fftypemethod=getArgumentParser().get_default('forcefield')[0])
+    mol = _canonicalizeAtomNames(mol)
 
     # Get rotatable dihedral angles
     mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
@@ -315,7 +315,7 @@ def main_parameterize(arguments=None):
     for method in args.forcefield:
 
         # Reload molecule for this fftypemethod
-        mol = canonicalizeAtomNames(mol, fftypemethod=method)
+        mol = _canonicalizeAtomNames(mol)
         mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
         print(" === Fitting for %s ===\n" % method)

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -69,7 +69,7 @@ def _get_molecule(args):
     from htmd.molecule.molecule import Molecule
     from htmd.parameterization.util import guessElements
 
-    mol = Molecule(args.filename)
+    mol = Molecule(args.filename, guessNE=['bonds'], guess=[])
 
     # Check if the file contain just one conformation
     if mol.numFrames != 1:

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -64,6 +64,24 @@ def getArgumentParser():
 
     return parser
 
+def _get_molecule(args):
+
+    from htmd.molecule.molecule import Molecule
+
+    mol = Molecule(args.filename)
+
+    if mol.numFrames != 1:
+        raise RuntimeError('{} has to contain only one molecule, but found {}'.format(args.filename, mol.numFrames))
+
+    # TODO: check elements
+
+    # TODO: check bonds
+
+    if np.unique(mol.name).size != mol.numAtoms:
+        raise RuntimeError('The atom names in {} has to be unique!'.format(args.filename))
+
+    return mol
+
 
 def printEnergies(molecule, parameters, filename):
     from htmd.ffevaluation.ffevaluate import FFEvaluate
@@ -179,8 +197,8 @@ def main_parameterize(arguments=None):
 
     args = getArgumentParser().parse_args(args=arguments)
 
-    if not os.path.exists(args.filename):
-        raise ValueError('File %s cannot be found' % args.filename)
+    # Get a molecule and check its validity
+    mol = _get_molecule(args)
 
     # Get RTF and PRM file names
     rtfFile, prmFile = None, None
@@ -242,8 +260,6 @@ def main_parameterize(arguments=None):
     from htmd.parameterization.writers import writeParameters
 
     # Get molecule with default atomtyping just for initial processing
-    from htmd.molecule.molecule import Molecule
-    mol = Molecule(args.filename)
     mol = canonicalizeAtomNames(mol, fftypemethod=getArgumentParser().get_default('forcefield')[0])
 
     # Get rotatable dihedral angles
@@ -298,7 +314,6 @@ def main_parameterize(arguments=None):
     for method in args.forcefield:
 
         # Reload molecule for this fftypemethod
-        mol = Molecule(args.filename)
         mol = canonicalizeAtomNames(mol, fftypemethod=method)
         mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -10,7 +10,7 @@ import logging
 import numpy as np
 
 from htmd.version import version
-from htmd.parameterization.fftype import fftypemethods, _canonicalizeAtomNames
+from htmd.parameterization.fftype import fftypemethods
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +78,9 @@ def _get_molecule(args):
         raise RuntimeError('The atom names in {} has to be unique!'.format(args.filename))
 
     mol = guessElements(mol, args.forcefield[0])
+
+    # Set segment ID
+    mol.segid[:] = 'L'
 
     # TODO: check bonds
 

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -260,9 +260,6 @@ def main_parameterize(arguments=None):
     from htmd.parameterization.parameterset import recreateParameters, createMultitermDihedralTypes, inventAtomTypes
     from htmd.parameterization.writers import writeParameters
 
-    # Get molecule with default atomtyping just for initial processing
-    mol = _canonicalizeAtomNames(mol)
-
     # Get rotatable dihedral angles
     mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
@@ -314,8 +311,6 @@ def main_parameterize(arguments=None):
     print('\n === Parameterizing %s ===\n' % args.filename)
     for method in args.forcefield:
 
-        # Reload molecule for this fftypemethod
-        mol = _canonicalizeAtomNames(mol)
         mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
         print(" === Fitting for %s ===\n" % method)

--- a/htmd/parameterization/cli.py
+++ b/htmd/parameterization/cli.py
@@ -67,18 +67,19 @@ def getArgumentParser():
 def _get_molecule(args):
 
     from htmd.molecule.molecule import Molecule
+    from htmd.parameterization.util import guessElements
 
     mol = Molecule(args.filename)
 
     if mol.numFrames != 1:
         raise RuntimeError('{} has to contain only one molecule, but found {}'.format(args.filename, mol.numFrames))
 
-    # TODO: check elements
-
-    # TODO: check bonds
-
     if np.unique(mol.name).size != mol.numAtoms:
         raise RuntimeError('The atom names in {} has to be unique!'.format(args.filename))
+
+    mol = guessElements(mol, args.forcefield[0])
+
+    # TODO: check bonds
 
     return mol
 

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -52,7 +52,9 @@ def _canonicalizeAtomNames(mol):
 
 def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpDir=None, netcharge=None):
     """
-    Function to assign atom types and force field parameters for a given molecule.
+    Assing atom types and force field parameters for a given molecule.
+    Additionally, atom masses and improper dihedral are set.
+    Optionally, atom charges can be set if `acCharges` is set (see below).
 
     The assignment can be done:
       1. For CHARMM CGenFF_2b6 with MATCH (method = 'CGenFF_2b6');
@@ -73,8 +75,8 @@ def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpD
         methods.
         Default: :func:`fftype.defaultFftypemethod <htmd.parameterization.fftype.defaultFftypemethod>`
     acCharges : str
-        Optionally assign charges with antechamber. Check `antechamber -L` for available options. Caution: This will
-        overwrite any charges defined in the mol2 file.
+        Optionally assign charges with antechamber. Check `antechamber -L` for available options.
+        Note: only works for GAFF and GAFF2.
     tmpDir: str
         Directory for temporary files. If None, a directory is created and
         deleted automatically.
@@ -91,6 +93,9 @@ def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpD
 
     if method not in fftypemethods:
         raise ValueError('Invalid method {}. Available methods {}'.format(method, ','.join(fftypemethods)))
+
+    if method == 'CGenFF_2b6' and acCharges:
+        raise ValueError('acCharges')
 
     if netcharge is None:
         netcharge = int(round(np.sum(mol.charge)))

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -289,6 +289,7 @@ class TestFftype(unittest.TestCase):
 
                 refDir = os.path.join(self.refDir, name, method)
                 self._init_mol(name, method, chargetuple)
+                # self._generate_references(name, method)
 
                 with open(os.path.join(refDir, 'mol_props.yaml')) as infile:
                     refProps = yaml.load(infile)

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -322,14 +322,14 @@ class TestFftype(unittest.TestCase):
 
         molFile = os.path.join(self.refDir, 'ethanolamine_wrongnames.mol2')
 
-        mol = Molecule(molFile)
+        mol = Molecule(molFile, guessNE=['bonds'], guess=[])
 
         with self.assertRaises(RuntimeError) as cm:
             fftype(mol, method='GAFF2')
 
-            self.assertEqual(cm.exception.args[0], 'Initial atom names BR1 were changed by antechamber to CR1. '
-                                                   'This probably means that the start of the atom name does not '
-                                                   'match element symbol. Please check the molecule.')
+        self.assertEqual(cm.exception.args[0], 'Initial atom names BR1 were changed by antechamber to CR1. '
+                                               'This probably means that the start of the atom name does not '
+                                               'match element symbol. Please check the molecule.')
 
 
 if __name__ == '__main__':

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -50,11 +50,6 @@ def _canonicalizeAtomNames(mol):
     return mol
 
 
-def listFftypemethods():
-    print('\n'.join(fftypemethods))
-    return
-
-
 def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpDir=None, netcharge=None):
     """
     Function to assign atom types and force field parameters for a given molecule.
@@ -213,11 +208,10 @@ class TestFftype(unittest.TestCase):
             acCharges = chargetuple[0]
             netcharge = chargetuple[1]
 
-        testMolecule = Molecule(molFile)
-        testMolecule = _canonicalizeAtomNames(testMolecule)
+        mol = Molecule(molFile)
 
         with TemporaryDirectory() as tmpDir:
-            self.testParameters, self.testMolecule = fftype(testMolecule,
+            self.testParameters, self.testMolecule = fftype(mol,
                                                             method=ffTypeMethod,
                                                             acCharges=acCharges,
                                                             netcharge=netcharge,

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -175,14 +175,11 @@ def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpD
     assert np.all(mol.element == elements)
 
     mol = mol.copy()
-    #mol.name = names
-    #mol.element = elements
     mol.atomtype = atomtypes
+    mol.masses = masses
+    mol.impropers = impropers
     if acCharges is not None:
         mol.charge = charges
-    mol.impropers = impropers
-    if np.sum(mol.masses) == 0:
-        mol.masses = masses
 
     return prm, mol
 

--- a/htmd/parameterization/fftype.py
+++ b/htmd/parameterization/fftype.py
@@ -3,16 +3,20 @@
 # Distributed under HTMD Software License Agreement
 # No redistribution in whole or part
 #
-
-import shutil
-import subprocess
 import os
+import logging
+import subprocess
+import unittest
+from yaml import load as yamlload
+from pickle import load as pickleload
 from tempfile import TemporaryDirectory
-from htmd.parameterization.readers import readPREPI, readFRCMOD, readRTF
+
 import numpy as np
 import parmed
-import logging
-import unittest
+
+from htmd.home import home
+from htmd.molecule.molecule import Molecule
+from htmd.parameterization.readers import readPREPI, readFRCMOD, readRTF
 
 logger = logging.getLogger(__name__)
 
@@ -97,47 +101,32 @@ def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpD
         netcharge = int(round(np.sum(mol.charge)))
         logger.warning('Using atomic charges from molecule object to calculate net charge')
 
-    prm = names = elements = atomtypes = charges = impropers = masses = None
     if rtfFile and prmFile:
         logger.info('Reading FF parameters from {} and {}'.format(rtfFile, prmFile))
         prm = parmed.charmm.CharmmParameterSet(rtfFile, prmFile)
         names, elements, atomtypes, charges, masses, impropers = readRTF(rtfFile)
-        # addParmedResidue(prm, names, elements, atomtypes, charges, impropers)
+
     else:
         logger.info('Assigning atom types with {}'.format(method))
-        # Find the executables
-        antechamber_binary = None
-        parmchk2_binary = None
-        match_binary = None
-        if method in ('GAFF', 'GAFF2'):
-            antechamber_binary = shutil.which('antechamber')
-            if not antechamber_binary:
-                raise RuntimeError('antechamber executable not found')
-            parmchk2_binary = shutil.which('parmchk2')
-            if not parmchk2_binary:
-                raise RuntimeError('parmchk2 executable not found')
-        elif method == 'CGenFF_2b6':
-            match_binary = shutil.which('match-typer')
-            if not match_binary:
-                raise RuntimeError('match-typer executable not found')
-        else:
-            raise ValueError('method {} is not implemented'.format(method))
+
+        renamed_mol = _canonicalizeAtomNames(mol)
 
         # Create a temporary directory
         with TemporaryDirectory() as tmpdir:
+
             # HACK to keep the files
             tmpdir = tmpdir if tmpDir is None else tmpDir
+            logger.debug('Temporary directory: {}'.format(tmpdir))
 
             if method in ('GAFF', 'GAFF2'):
-                from htmd.molecule.molecule import Molecule
-                # Write the molecule to a file
-                mol.write(os.path.join(tmpdir, 'mol.mol2'))
 
-                # Run antechamber
+                # Write the molecule to a file
+                renamed_mol.write(os.path.join(tmpdir, 'mol.mol2'))
 
                 atomtype = method.lower()
 
-                cmd = [antechamber_binary,
+                # Run antechamber
+                cmd = ['antechamber',
                        '-at', atomtype,
                        '-nc', str(netcharge),
                        '-fi', 'mol2',
@@ -151,53 +140,48 @@ def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpD
                     raise RuntimeError('"antechamber" failed')
 
                 # Run parmchk2
-                returncode = subprocess.call([parmchk2_binary,
-                                              '-f', 'prepi',
-                                              '-s', atomtype,
-                                              '-i', 'mol.prepi',
-                                              '-o', 'mol.frcmod',
-                                              '-a', 'Y'], cwd=tmpdir)
+                cmd = ['parmchk2',
+                       '-f', 'prepi',
+                       '-s', atomtype,
+                       '-i', 'mol.prepi',
+                       '-o', 'mol.frcmod',
+                       '-a', 'Y']
+                returncode = subprocess.call(cmd, cwd=tmpdir)
                 if returncode != 0:
                     raise RuntimeError('"parmchk2" failed')
 
-                # Check if antechamber did changes in atom names (and suggest the user to fix the names)
-                acmol = Molecule(os.path.join(tmpdir, 'NEWPDB.PDB'), type='pdb')
-                acmol.name = np.array([n.upper() for n in acmol.name]).astype(np.object)
-                if len(np.setdiff1d(mol.name, acmol.name)) != 0 or len(np.setdiff1d(acmol.name, mol.name)) != 0:
-                    raise RuntimeError('Initial atom names {} were changed by antechamber to {}. This probably means '
-                                       'that the start of the atom name does not match element symbol. Please check '
-                                       'the molecule.'.format(','.join(np.setdiff1d(mol.name, acmol.name)),
-                                                              ','.join(np.setdiff1d(acmol.name, mol.name))
-                                                              )
-                                       )
-
                 # Read the results
                 prm = parmed.amber.AmberParameterSet(os.path.join(tmpdir, 'mol.frcmod'))
-                names, atomtypes, charges, impropers = readPREPI(mol, os.path.join(tmpdir, 'mol.prepi'))
+                names, atomtypes, charges, impropers = readPREPI(renamed_mol, os.path.join(tmpdir, 'mol.prepi'))
                 masses, elements = readFRCMOD(atomtypes, os.path.join(tmpdir, 'mol.frcmod'))
+
             elif method == 'CGenFF_2b6':
 
                 # Write the molecule to a file
-                mol.write(os.path.join(tmpdir, 'mol.pdb'))
+                renamed_mol.write(os.path.join(tmpdir, 'mol.pdb'))
 
                 # Run match-type
-                returncode = subprocess.call([match_binary,
-                                              '-charge', str(netcharge),
-                                              '-forcefield', 'top_all36_cgenff_new',
-                                              'mol.pdb'], cwd=tmpdir)
+                cmd = ['match-typer',
+                       '-charge', str(netcharge),
+                       '-forcefield', 'top_all36_cgenff_new',
+                       'mol.pdb']
+                returncode = subprocess.call(cmd, cwd=tmpdir)
                 if returncode != 0:
                     raise RuntimeError('"match-typer" failed')
 
                 prm = parmed.charmm.CharmmParameterSet(os.path.join(tmpdir, 'mol.rtf'), os.path.join(tmpdir, 'mol.prm'))
                 names, elements, atomtypes, charges, masses, impropers = readRTF(os.path.join(tmpdir, 'mol.rtf'))
-                # addParmedResidue(prm, names, elements, atomtypes, charges, impropers)
+
             else:
                 raise ValueError('Invalid method {}'.format(method))
 
-    # Substituting values from the read-in topology
+        assert np.all(renamed_mol.name == names)
+
+    assert np.all(mol.element == elements)
+
     mol = mol.copy()
-    mol.name = names
-    mol.element = elements
+    #mol.name = names
+    #mol.element = elements
     mol.atomtype = atomtypes
     if acCharges is not None:
         mol.charge = charges
@@ -210,30 +194,18 @@ def fftype(mol, rtfFile=None, prmFile=None, method='GAFF2', acCharges=None, tmpD
 
 class TestFftype(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super(TestFftype, self).__init__(*args, **kwargs)
-        from htmd.home import home
-        from htmd.molecule.molecule import Molecule
-        from htmd.parameterization.util import getEquivalentsAndDihedrals
-        from yaml import load as yamlload
-        from pickle import load as pickleload
+    def setUp(self):
         self.refDir = home(dataDir='test-fftype')
-        self.Molecule = Molecule
-        self.canonicalizeAtomNames = _canonicalizeAtomNames
-        self.getEquivalentsAndDihedrals = getEquivalentsAndDihedrals
-        self.yamlload = yamlload
-        self.pickleload = pickleload
 
     def assertListAlmostEqual(self, list1, list2, places=7):
         self.assertEqual(len(list1), len(list2))
         for a, b in zip(list1, list2):
             self.assertAlmostEqual(a, b, places=places)
 
-    def setUp(self):
-        pass
-
     def _init_mol(self, molName, ffTypeMethod, chargetuple):
+
         molFile = os.path.join(self.refDir, '{}.mol2'.format(molName))
+
         if chargetuple == 'None':
             acCharges = None
             netcharge = None
@@ -241,22 +213,16 @@ class TestFftype(unittest.TestCase):
             acCharges = chargetuple[0]
             netcharge = chargetuple[1]
 
-        testMolecule = self.Molecule(molFile)
-        testMolecule = self.canonicalizeAtomNames(testMolecule, ffTypeMethod)
-        testMolecule, _, _ = self.getEquivalentsAndDihedrals(testMolecule)
+        testMolecule = Molecule(molFile)
+        testMolecule = _canonicalizeAtomNames(testMolecule)
 
-        from tempfile import mkdtemp
-        tmpDir = mkdtemp(suffix='fftype')
-        testParameters, testMolecule = fftype(testMolecule,
-                                              method=ffTypeMethod,
-                                              acCharges=acCharges,
-                                              netcharge=netcharge,
-                                              tmpDir=tmpDir)
-        testIntermediaryFiles = sorted(os.listdir(tmpDir))
-
-        self.testMolecule = testMolecule
-        self.testParameters = testParameters
-        self.testIntermediaryFiles = testIntermediaryFiles
+        with TemporaryDirectory() as tmpDir:
+            self.testParameters, self.testMolecule = fftype(testMolecule,
+                                                            method=ffTypeMethod,
+                                                            acCharges=acCharges,
+                                                            netcharge=netcharge,
+                                                            tmpDir=tmpDir)
+            self.testIntermediaryFiles = sorted(os.listdir(tmpDir))
 
     def _generate_references(self, name, method):
         import numbers
@@ -287,6 +253,7 @@ class TestFftype(unittest.TestCase):
         print('[{}]'.format(', '.join('\'{}\''.format(i) for i in self.testIntermediaryFiles)))
 
     def _test_mol_props(self, names, elements, atomtypes, charges, impropers):
+
         self.assertEqual(list(self.testMolecule.name), names)
         self.assertEqual(list(self.testMolecule.element), elements)
         self.assertEqual(list(self.testMolecule.atomtype), atomtypes)
@@ -315,79 +282,31 @@ class TestFftype(unittest.TestCase):
 
         for name, method, chargetuple in toTest:
             with self.subTest(name=name, method=method, chargetuple=chargetuple):
+
                 refDir = os.path.join(self.refDir, name, method)
                 self._init_mol(name, method, chargetuple)
-                # self._generate_references(name, method)
-                with open(os.path.join(refDir, 'mol_props.yaml'), 'r') as infile:
-                    refProps = self.yamlload(infile)
+
+                with open(os.path.join(refDir, 'mol_props.yaml')) as infile:
+                    refProps = yamlload(infile)
                 self._test_mol_props(**refProps)
+
                 with open(os.path.join(refDir, 'params.p'), 'rb') as infile:
-                    refParams = self.pickleload(infile)
+                    refParams = pickleload(infile)
                 self._test_params(refParams)
-                with open(os.path.join(refDir, 'intermediary_files.yaml'), 'r') as infile:
-                    refFiles = self.yamlload(infile)
+
+                with open(os.path.join(refDir, 'intermediary_files.yaml')) as infile:
+                    refFiles = yamlload(infile)
                 self._test_intermediary_files(refFiles)
 
     def test_broken_atomname(self):
-        molFile = os.path.join(self.refDir, '{}.mol2'.format('ethanolamine_wrongnames'))
 
-        testMolecule = self.Molecule(molFile)
-        testMolecule = self.canonicalizeAtomNames(testMolecule, 'GAFF2')
-        testMolecule, _, _ = self.getEquivalentsAndDihedrals(testMolecule)
+        molFile = os.path.join(self.refDir, 'ethanolamine_wrongnames.mol2')
 
-        from tempfile import mkdtemp
-        tmpDir = mkdtemp(suffix='fftype')
-        with self.assertRaises(RuntimeError) as cm:
-            _, _ = fftype(testMolecule,
-                          method='GAFF2',
-                          acCharges=None,
-                          netcharge=None,
-                          tmpDir=tmpDir)
+        mol = Molecule(molFile)
 
-        self.assertEqual(cm.exception.args[0], 'Initial atom names BR1 were changed by antechamber to CR1. '
-                                               'This probably means that the start of the atom name does not '
-                                               'match element symbol. Please check the molecule.')
+        with self.assertRaises(RuntimeError):
+            fftype(mol, method='GAFF2')
 
 
 if __name__ == '__main__':
-
-    import sys
-
     unittest.main(verbosity=2)
-
-    import re
-    from htmd.home import home
-    from htmd.molecule.molecule import Molecule
-    from htmd.parameterization.writers import writeRTF, writePRM
-    from htmd.parameterization.util import getEquivalentsAndDihedrals, logger
-
-    # BUG: MATCH does not work on Mac!
-    if 'TRAVIS_OS_NAME' in os.environ:
-        if os.environ['TRAVIS_OS_NAME'] == 'osx':
-            sys.exit(0)
-
-    molFile = os.path.join(home('building-protein-ligand'), 'benzamidine.mol2')
-    refDir = home(dataDir='test-fftype/benzamidine')
-    mol = Molecule(molFile)
-
-    with TemporaryDirectory() as tmpDir:
-
-        mol = _canonicalizeAtomNames(mol)
-        mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
-        parameters, mol = fftype(mol, method='CGenFF_2b6')
-        writeRTF(mol, parameters, 0, os.path.join(tmpDir, 'cgenff.rtf'))
-        writePRM(mol, parameters, os.path.join(tmpDir, 'cgenff.prm'))
-
-        for testFile in os.listdir(refDir):
-            print(testFile)
-            with open(os.path.join(refDir, testFile)) as refFile:
-                with open(os.path.join(tmpDir, testFile)) as tmpFile:
-                    # The line order for antechamber is unstable, so the files are sorted.
-                    # Also, it get rids of HTMD version string
-                    refData = sorted([line for line in refFile.readlines() if not re.search('HTMD', line)])
-                    tmpData = sorted([line for line in tmpFile.readlines() if not re.search('HTMD', line)])
-                    assert refData == tmpData
-
-    with TemporaryDirectory() as tmpDir:
-        parameters, mol = fftype(mol, method='CGenFF_2b6', tmpDir=tmpDir)
-        assert sorted(os.listdir(tmpDir)) == ['mol.pdb', 'mol.prm', 'mol.rtf', 'top_mol.rtf']

--- a/htmd/parameterization/parameterset.py
+++ b/htmd/parameterization/parameterset.py
@@ -155,12 +155,13 @@ class Test(unittest.TestCase):
     def setUp(self):
         from htmd.home import home
         from htmd.parameterization.fftype import fftype
-        from htmd.parameterization.util import canonicalizeAtomNames, getEquivalentsAndDihedrals
+        from htmd.parameterization.util import getEquivalentsAndDihedrals
+        from htmd.parameterization.fftype import _canonicalizeAtomNames
         from htmd.molecule.molecule import Molecule
 
         molFile = os.path.join(home('test-param'), 'glycol.mol2')
         mol = Molecule(molFile)
-        mol = canonicalizeAtomNames(mol, 'GAFF2')
+        mol = _canonicalizeAtomNames(mol)
         mol, self.equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
         _, mol = fftype(mol, method='GAFF2')
         self.mol = mol

--- a/htmd/parameterization/parameterset.py
+++ b/htmd/parameterization/parameterset.py
@@ -1,6 +1,13 @@
-import numpy as np
+# (c) 2015-2018 Acellera Ltd http://www.acellera.com
+# All Rights Reserved
+# Distributed under HTMD Software License Agreement
+# No redistribution in whole or part
+#
+import os
 import re
+import unittest
 
+import numpy as np
 
 _ATOM_TYPE_REG_EX = re.compile('^\S+x\d+$')
 
@@ -61,6 +68,7 @@ def recreateParameters(mol, originaltypes, parameters):
 
     return newparams
 
+
 def createMultitermDihedralTypes(parameters, nterms=6, scee=1.2, scnb=2):
     from parmed.topologyobjects import DihedralTypeList, DihedralType
     from copy import deepcopy
@@ -82,6 +90,7 @@ def createMultitermDihedralTypes(parameters, nterms=6, scee=1.2, scnb=2):
         parameters.dihedral_types[key] = dihlist
 
     return parameters
+
 
 def inventAtomTypes(mol, fit_dihedrals, equivalents):
     """
@@ -148,20 +157,16 @@ def _getEquivalentDihedrals(mol, equivalents, dihedral):
     return unique_dihedrals
 
 
-import unittest
-import os
 class Test(unittest.TestCase):
 
     def setUp(self):
         from htmd.home import home
         from htmd.parameterization.fftype import fftype
         from htmd.parameterization.util import getEquivalentsAndDihedrals
-        from htmd.parameterization.fftype import _canonicalizeAtomNames
         from htmd.molecule.molecule import Molecule
 
         molFile = os.path.join(home('test-param'), 'glycol.mol2')
         mol = Molecule(molFile)
-        mol = _canonicalizeAtomNames(mol)
         mol, self.equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
         _, mol = fftype(mol, method='GAFF2')
         self.mol = mol
@@ -188,5 +193,4 @@ class Test(unittest.TestCase):
 
 
 if __name__ == '__main__':
-
     unittest.main(verbosity=2)

--- a/htmd/parameterization/test.py
+++ b/htmd/parameterization/test.py
@@ -196,7 +196,7 @@ class TestParameterize(unittest.TestCase):
         refDir = os.path.join(self.dataDir, 'glycol_dihed_fix_restart')
         resDir = os.path.join(self.testDir, 'glycol_dihed_fix_restart_2')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        dihedrals = ['O1-C1-C2-O2', 'C1-C2-O2-H6']
+        dihedrals = ['O1-C2-C3-O4', 'C2-C3-O4-H10']
         self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type Gasteiger --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
         self._testFiles(refDir, resDir)
 
@@ -204,7 +204,7 @@ class TestParameterize(unittest.TestCase):
         refDir = os.path.join(self.dataDir, 'glycol_dihed_select_1_restart')
         resDir = os.path.join(self.testDir, 'glycol_dihed_select_1_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        dihedrals = ['O1-C1-C2-O2',]
+        dihedrals = ['O1-C2-C3-O4']
         self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type Gasteiger --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
         self._testFiles(refDir, resDir)
 
@@ -212,7 +212,7 @@ class TestParameterize(unittest.TestCase):
         refDir = os.path.join(self.dataDir, 'glycol_dihed_select_2_restart')
         resDir = os.path.join(self.testDir, 'glycol_dihed_select_2_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        dihedrals = ['C1-C2-O2-H6',]
+        dihedrals = ['C2-C3-O4-H10']
         self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type Gasteiger --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
         self._testFiles(refDir, resDir)
 

--- a/htmd/parameterization/test.py
+++ b/htmd/parameterization/test.py
@@ -75,6 +75,18 @@ class TestParameterize(unittest.TestCase):
 
         print('')
 
+    def test_parameterize_speed(self):
+        import time
+        _started_at = time.time()
+
+        command = 'parameterize -h'
+        print('')  # Just for a better readability
+        returncode = call(command.split())
+        self.assertEqual(returncode, 0)
+
+        elapsed = time.time() - _started_at
+        self.assertLessEqual(elapsed, 1.5)
+
     def test_h2o2_list(self):
         refDir = os.path.join(self.dataDir, 'h2o2_list')
         resDir = os.path.join(self.testDir, 'h2o2_list')

--- a/htmd/parameterization/test.py
+++ b/htmd/parameterization/test.py
@@ -6,8 +6,10 @@
 import os
 import sys
 import shutil
+import time
 import unittest
 from subprocess import call
+
 import numpy as np
 
 from htmd.home import home
@@ -76,7 +78,7 @@ class TestParameterize(unittest.TestCase):
         print('')
 
     def test_parameterize_speed(self):
-        import time
+
         _started_at = time.time()
 
         command = 'parameterize -h'

--- a/htmd/parameterization/test.py
+++ b/htmd/parameterization/test.py
@@ -84,26 +84,26 @@ class TestParameterize(unittest.TestCase):
     def test_h2o2_gaff2(self):
         refDir = os.path.join(self.dataDir, 'h2o2_gaff2')
         resDir = os.path.join(self.testDir, 'h2o2_gaff2')
-        self._execute(refDir, resDir, 'parameterize input.mol2 -f GAFF2 --charge-type None --no-min --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -f GAFF2 --charge-type Gasteiger --no-min --no-dihed')
         self._testFiles(refDir, resDir)
 
     def test_h2o2_outdir(self):
         refDir = os.path.join(self.dataDir, 'h2o2_outdir')
         resDir = os.path.join(self.testDir, 'h2o2_outdir')
-        self._execute(refDir, resDir, 'parameterize input.mol2 -f GAFF2 --charge-type None --no-min --no-dihed -o dir')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -f GAFF2 --charge-type Gasteiger --no-min --no-dihed -o dir')
         self._testFiles(refDir, resDir)
 
     def test_h2o2_min(self):
         refDir = os.path.join(self.dataDir, 'h2o2_min')
         resDir = os.path.join(self.testDir, 'h2o2_min')
-        self._execute(refDir, resDir, 'parameterize input.mol2 -f GAFF2 --charge-type None --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -f GAFF2 --charge-type Gasteiger --no-dihed')
         self._testFiles(refDir, resDir)
 
     def test_h2o2_min_restart(self):
         refDir = os.path.join(self.dataDir, 'h2o2_min_restart')
         resDir = os.path.join(self.testDir, 'h2o2_min_restart')
         shutil.copytree(os.path.join(refDir, 'minimize'), os.path.join(resDir, 'minimize'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type None --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-dihed')
         self._testFiles(refDir, resDir)
 
     def test_h2o2_esp(self):
@@ -123,28 +123,28 @@ class TestParameterize(unittest.TestCase):
     def test_h2o2_dihed_fix(self):
         refDir = os.path.join(self.dataDir, 'h2o2_dihed_fix')
         resDir = os.path.join(self.testDir, 'h2o2_dihed_fix')
-        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --no-esp --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --charge-type Gasteiger --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     def test_h2o2_dihed_fix_restart(self):
         refDir = os.path.join(self.dataDir, 'h2o2_dihed_fix_restart')
         resDir = os.path.join(self.testDir, 'h2o2_dihed_fix_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type None --no-min --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(os.environ.get('HTMD_VERYLONGTESTS') == 'yes', 'Too long')
     def test_h2o2_dihed_opt(self):
         refDir = os.path.join(self.dataDir, 'h2o2_dihed_opt')
         resDir = os.path.join(self.testDir, 'h2o2_dihed_opt')
-        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --no-esp')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min')
         self._testFiles(refDir, resDir)
 
     def test_h2o2_dihed_opt_restart(self):
         refDir = os.path.join(self.dataDir, 'h2o2_dihed_opt_restart')
         resDir = os.path.join(self.testDir, 'h2o2_dihed_opt_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-opt'), os.path.join(resDir, 'dihedral-opt'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type None --no-min')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min')
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(sys.version_info.major == 3 and sys.version_info.minor > 5, 'Python 3.5 issue')
@@ -168,28 +168,28 @@ class TestParameterize(unittest.TestCase):
     def test_ethene_dihed_fix(self):
         refDir = os.path.join(self.dataDir, 'ethene_dihed_fix')
         resDir = os.path.join(self.testDir, 'ethene_dihed_fix')
-        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --no-esp --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     def test_ethene_dihed_fix_restart(self):
         refDir = os.path.join(self.dataDir, 'ethene_dihed_fix_restart')
         resDir = os.path.join(self.testDir, 'ethene_dihed_fix_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type None --no-min --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(os.environ.get('HTMD_VERYLONGTESTS') == 'yes', 'Too long')
     def test_glycol_dihed_fix(self):
         refDir = os.path.join(self.dataDir, 'glycol_dihed_fix')
         resDir = os.path.join(self.testDir, 'glycol_dihed_fix')
-        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --no-esp --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     def test_glycol_dihed_fix_restart(self):
         refDir = os.path.join(self.dataDir, 'glycol_dihed_fix_restart')
         resDir = os.path.join(self.testDir, 'glycol_dihed_fix_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type None --no-min --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     def test_glycol_dihed_fix_restart_2(self):
@@ -197,7 +197,7 @@ class TestParameterize(unittest.TestCase):
         resDir = os.path.join(self.testDir, 'glycol_dihed_fix_restart_2')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
         dihedrals = ['O1-C1-C2-O2', 'C1-C2-O2-H6']
-        self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type None --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
+        self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type Gasteiger --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
         self._testFiles(refDir, resDir)
 
     def test_glycol_dihed_select_1_restart(self):
@@ -205,7 +205,7 @@ class TestParameterize(unittest.TestCase):
         resDir = os.path.join(self.testDir, 'glycol_dihed_select_1_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
         dihedrals = ['O1-C1-C2-O2',]
-        self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type None --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
+        self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type Gasteiger --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
         self._testFiles(refDir, resDir)
 
     def test_glycol_dihed_select_2_restart(self):
@@ -213,14 +213,14 @@ class TestParameterize(unittest.TestCase):
         resDir = os.path.join(self.testDir, 'glycol_dihed_select_2_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
         dihedrals = ['C1-C2-O2-H6',]
-        self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type None --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
+        self._execute(refDir, resDir, 'parameterize input.mol2 -d {} --charge-type Gasteiger --no-min --no-dihed-opt'.format(' '.join(dihedrals)))
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(os.environ.get('HTMD_VERYLONGTESTS') == 'yes', 'Too long')
     def test_ethanolamine_dihed_fix(self):
         refDir = os.path.join(self.dataDir, 'ethanolamine_dihed_fix')
         resDir = os.path.join(self.testDir, 'ethanolamine_dihed_fix')
-        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --no-esp --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(os.environ.get('HTMD_LONGTESTS') == 'yes', 'Too long')
@@ -228,7 +228,7 @@ class TestParameterize(unittest.TestCase):
         refDir = os.path.join(self.dataDir, 'ethanolamine_dihed_fix_restart')
         resDir = os.path.join(self.testDir, 'ethanolamine_dihed_fix_restart')
         shutil.copytree(os.path.join(refDir, 'dihedral-single-point'), os.path.join(resDir, 'dihedral-single-point'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 --no-min --no-esp --no-dihed-opt')
+        self._execute(refDir, resDir, 'parameterize input.mol2 --charge-type Gasteiger --no-min --no-dihed-opt')
         self._testFiles(refDir, resDir)
 
     def test_benzamidine_gasteiger(self):
@@ -240,19 +240,19 @@ class TestParameterize(unittest.TestCase):
     def test_benzamidine_gaff(self):
         refDir = os.path.join(self.dataDir, 'benzamidine_gaff')
         resDir = os.path.join(self.testDir, 'benzamidine_gaff')
-        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF --charge-type None --no-min --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF --charge-type Gasteiger --no-min --no-dihed')
         self._testFiles(refDir, resDir)
 
     def test_benzamidine_gaff2(self):
         refDir = os.path.join(self.dataDir, 'benzamidine_gaff2')
         resDir = os.path.join(self.testDir, 'benzamidine_gaff2')
-        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF2 --charge-type None --no-min --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF2 --charge-type Gasteiger --no-min --no-dihed')
         self._testFiles(refDir, resDir)
 
     def test_benzamidine_cgenff(self):
         refDir = os.path.join(self.dataDir, 'benzamidine_cgenff')
         resDir = os.path.join(self.testDir, 'benzamidine_cgenff')
-        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff CGenFF_2b6 --charge-type None --no-min --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff CGenFF_2b6 --charge-type Gasteiger --no-min --no-dihed')
         self._testFiles(refDir, resDir)
 
     def test_benzamidine_rtf_prm(self):
@@ -261,7 +261,7 @@ class TestParameterize(unittest.TestCase):
         os.makedirs(resDir, exist_ok=True)
         shutil.copy(os.path.join(refDir, 'input.rtf'), resDir)
         shutil.copy(os.path.join(refDir, 'input.prm'), resDir)
-        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff CGenFF_2b6 --rtf-prm input.rtf input.prm --charge-type None --no-min --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff CGenFF_2b6 --rtf-prm input.rtf input.prm --charge-type Gasteiger --no-min --no-dihed')
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(os.environ.get('HTMD_VERYLONGTESTS') == 'yes', 'Too long')

--- a/htmd/parameterization/test.py
+++ b/htmd/parameterization/test.py
@@ -288,7 +288,7 @@ class TestParameterize(unittest.TestCase):
         resDir = os.path.join(self.testDir, 'benzamidine_esp_freeze_restart')
         shutil.copytree(os.path.join(refDir, 'minimize'), os.path.join(resDir, 'minimize'))
         shutil.copytree(os.path.join(refDir, 'esp'), os.path.join(resDir, 'esp'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF2 CGenFF_2b6 --fix-charge N2 --basis 6-31G* --no-dihed')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF2 CGenFF_2b6 --fix-charge N14 --basis 6-31G* --no-dihed')
         self._testFiles(refDir, resDir)
 
     @unittest.skipUnless(os.environ.get('HTMD_UNSTABLETESTS') == 'yes', 'Unstable')
@@ -298,7 +298,7 @@ class TestParameterize(unittest.TestCase):
         shutil.copytree(os.path.join(refDir, 'minimize'), os.path.join(resDir, 'minimize'))
         shutil.copytree(os.path.join(refDir, 'esp'), os.path.join(resDir, 'esp'))
         shutil.copytree(os.path.join(refDir, 'dihedral-opt'), os.path.join(resDir, 'dihedral-opt'))
-        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF2 CGenFF_2b6 -d C2-C1-C7-N1 --basis 6-31G*')
+        self._execute(refDir, resDir, 'parameterize input.mol2 -c 1 -ff GAFF2 CGenFF_2b6 -d C2-C1-C7-N13 --basis 6-31G*')
         self._testFiles(refDir, resDir)
 
 

--- a/htmd/parameterization/util.py
+++ b/htmd/parameterization/util.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def getEquivalentsAndDihedrals(mol):
+
     from htmd.molecule.util import guessAnglesAndDihedrals
     from htmd.parameterization.detect import detectParameterizableDihedrals, detectEquivalentAtoms
 
@@ -27,6 +28,12 @@ def guessElements(mol, fftypemethod):
     """
     Guess element from an atom name
     """
+
+    from htmd.parameterization.fftype import fftypemethods
+
+    if fftypemethod not in fftypemethods:
+        raise ValueError('Invalid "fftypemethod": {}. Valid methods: {}'
+                         ''.format(fftypemethod, ','.join(fftypemethods)))
 
     elements = {}
     elements['CGenFF_2b6'] = ['H', 'C', 'N', 'O', 'F', 'S', 'P', 'Cl', 'Br', 'I']

--- a/htmd/parameterization/util.py
+++ b/htmd/parameterization/util.py
@@ -23,36 +23,6 @@ def getEquivalentsAndDihedrals(mol):
     return mol, equivalents, all_dihedrals
 
 
-def canonicalizeAtomNames(mol, fftypemethod, inplace=False, _logger=True):
-    """
-    This fixes up the atom naming and reside name to be consistent.
-    NB this scheme matches what MATCH does.
-    Don't change it or the naming will be inconsistent with the RTF.
-    """
-    if not inplace:
-        mol = mol.copy()
-    mol.segid[:] = 'L'
-    if _logger:
-        logger.info('Rename segment to %s' % mol.segid[0])
-    mol.resname[:] = 'MOL'
-    if _logger:
-        logger.info('Rename residue to %s' % mol.resname[0])
-
-    sufices = {}
-    for i in range(mol.numAtoms):
-        name = mol.element[i].upper()
-
-        sufices[name] = sufices.get(name, 0) + 1
-        name += str(sufices[name])
-
-        if _logger:
-            logger.info('Rename atom %d: %-4s --> %-4s' % (i, mol.name[i], name))
-        mol.name[i] = name
-
-    if not inplace:
-        return mol
-
-
 def guessElements(mol, fftypemethod):
     """
     Guess element from an atom name

--- a/htmd/parameterization/util.py
+++ b/htmd/parameterization/util.py
@@ -40,7 +40,7 @@ def canonicalizeAtomNames(mol, fftypemethod, inplace=False, _logger=True):
 
     sufices = {}
     for i in range(mol.numAtoms):
-        name = guessElementForFftype(i, mol, fftypemethod).upper()
+        name = mol.element[i].upper()
 
         sufices[name] = sufices.get(name, 0) + 1
         name += str(sufices[name])
@@ -53,79 +53,49 @@ def canonicalizeAtomNames(mol, fftypemethod, inplace=False, _logger=True):
         return mol
 
 
-def guessElementForFftype(index, mol, fftypemethod):
+def guessElements(mol, fftypemethod):
     """
     Guess element from an atom name
-
-    >>> from htmd.parameterization.util import guessElementForFftype
-    >>> guessElementForFftype('C')
-    'C'
-    >>> guessElementForFftype('C1')
-    'C'
-    >>> guessElementForFftype('C42')
-    'C'
-    >>> guessElementForFftype('C7S')
-    'C'
-    >>> guessElementForFftype('HN1')
-    'H'
-    >>> guessElementForFftype('CL')
-    'Cl'
-    >>> guessElementForFftype('CA1')
-    'Ca'
     """
 
-    from htmd.parameterization.fftype import fftypemethods
+    elements = {}
+    elements['CGenFF_2b6'] = ['H', 'C', 'N', 'O', 'F', 'S', 'P', 'Cl', 'Br', 'I']
+    elements['GAFF']       = ['H', 'C', 'N', 'O', 'F', 'S', 'P', 'Cl', 'Br', 'I']
+    elements['GAFF2']      = ['H', 'C', 'N', 'O', 'F', 'S', 'P', 'Cl', 'Br', 'I']
 
-    elements = dict()
-    elements['GAFF'] = ['H', 'O', 'C', 'N', 'S', 'P', 'F', 'Cl', 'Br', 'I']
-    elements['GAFF2'] = ['H', 'O', 'C', 'N', 'S', 'P', 'F', 'Cl', 'Br', 'I']
+    mol = mol.copy()
 
-    if fftypemethod == 'CGenFF_2b6':
-        import periodictable
-        name = mol.name[index]
-        symbol = name.capitalize()
+    for i, name in enumerate(mol.name):
 
-        while symbol:
-            try:
-                element = periodictable.elements.symbol(symbol)
-            except ValueError:
-                symbol = symbol[:-1]
-            else:
-                return element.symbol
+        candidates = [element for element in elements[fftypemethod] if name.capitalize().startswith(element)]
 
-        raise ValueError('Cannot guess element from atom name: {}'.format(name))
-    elif fftypemethod in ('GAFF2', 'GAFF'):
-        name = mol.name[index]
-        scan = {'matches': 0, 'elements': []}
-        for e in elements[fftypemethod]:
-            if name.capitalize().startswith(e):
-                scan['matches'] += 1
-                scan['elements'].append(e)
+        if len(candidates) == 1:
+            mol.element[i] = candidates[0]
+            continue
 
-        if scan['matches'] == 1:
-            return scan['elements'][0]
-        elif scan['matches'] > 1:
-            # Should only happen with atom names starting with CL
-            import networkx as nx
+        if candidates == ['C', 'Cl']:
 
-            # Guess bonds if not present
             if len(mol.bonds) == 0:
-                logger.warning('No bonds found! Guessing them...')
-                mol.bonds = mol._guessBonds()
+                raise RuntimeError('No chemical bonds found in the molecule')
 
-            g = nx.Graph()
-            g.add_edges_from(mol.bonds)
+            # Create a molecular graph
+            import networkx as nx
+            graph = nx.Graph()
+            graph.add_edges_from(mol.bonds)
 
-            if len(g[index]) == 1:
-                return 'Cl'
-            else:
-                return 'C'
-        else:
-            raise ValueError('Cannot create element from atom name: {}. It probably does not match the atom elements'
-                             'available for {}: {}'.format(name, fftypemethod, elements[fftypemethod]))
-    else:
-        raise RuntimeError('Not a valid fftypemethod: {}. Valid methods: {}'.format(fftypemethod,
-                                                                                    ','.join(fftypemethods)))
+            if len(graph[i]) in (2, 3, 4):
+                mol.element[i] = 'C'
+                continue
+
+            if len(graph[i]) == 1:
+                mol.element[i] = 'Cl'
+                continue
+
+        raise ValueError('Cannot guess element from atom name: {}. '
+                         'It does not match any of the expected elements ({}) for {}.'
+                         ''.format(name, elements[fftypemethod], fftypemethod))
+
+    return mol
 
 
 def centreOfMass(mol):

--- a/htmd/parameterization/writers.py
+++ b/htmd/parameterization/writers.py
@@ -201,7 +201,8 @@ def writeRTF(mol, parameters, netcharge, filename):
         val = parameters.atom_types[type]
         print("MASS %5d %s %8.5f %s" % (val.number, type, val.mass, periodictable.elements[val.atomic_number]), file=f)
     print("\nAUTO ANGLES DIHE\n", file=f)
-    print("RESI  MOL %8.5f" % netcharge, file=f)
+    assert np.unique(mol.resname).size == 1 # Check if all atoms have the same residue name
+    print("RESI %s %8.5f" % (mol.resname[0], netcharge), file=f)
     print("GROUP", file=f)
 
     maxnamelen = max(4, np.max([len(na) for na in mol.name]))  # Minimum field size of 4

--- a/htmd/qm/custom.py
+++ b/htmd/qm/custom.py
@@ -50,8 +50,7 @@ class OMMMinimizer(Minimizer):
 
         Examples
         --------
-        >>> from htmd.parameterization.fftype import fftype
-        >>> from htmd.parameterization.util import canonicalizeAtomNames
+        >>> from htmd.parameterization.fftype import fftype, _canonicalizeAtomNames
         >>> from htmd.molecule.molecule import Molecule
 
         >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')

--- a/htmd/qm/custom.py
+++ b/htmd/qm/custom.py
@@ -50,12 +50,11 @@ class OMMMinimizer(Minimizer):
 
         Examples
         --------
-        >>> from htmd.parameterization.fftype import fftype, _canonicalizeAtomNames
+        >>> from htmd.parameterization.fftype import fftype
         >>> from htmd.molecule.molecule import Molecule
 
         >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
         >>> mol = Molecule(molFile)
-        >>> mol = canonicalizeAtomNames(mol)
         >>> prm, mol = fftype(mol, method='GAFF2')
         >>> mini = OMMMinimizer(mol, prm)
         >>> minimcoor = mini.minimize(mol.coords, restrained_dihedrals=[0, 1, 6, 12])

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -34,7 +34,7 @@ class FakeQM(QMBase):
     >>> from tempfile import TemporaryDirectory
     >>> from htmd.home import home
     >>> from htmd.numbautil import dihedralAngle
-    >>> from htmd.parameterization.fftype import fftype, _canonicalizeAtomNames
+    >>> from htmd.parameterization.fftype import fftype
     >>> from htmd.parameterization.util import getEquivalentsAndDihedrals
     >>> from htmd.molecule.molecule import Molecule
     >>> from htmd.qm.fake import FakeQM
@@ -182,7 +182,7 @@ class FakeQM2(FakeQM):
     >>> from tempfile import TemporaryDirectory
     >>> from htmd.home import home
     >>> from htmd.numbautil import dihedralAngle
-    >>> from htmd.parameterization.fftype import fftype, _canonicalizeAtomNames
+    >>> from htmd.parameterization.fftype import fftype
     >>> from htmd.molecule.molecule import Molecule
     >>> from htmd.qm.fake import FakeQM2
 

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -34,8 +34,8 @@ class FakeQM(QMBase):
     >>> from tempfile import TemporaryDirectory
     >>> from htmd.home import home
     >>> from htmd.numbautil import dihedralAngle
-    >>> from htmd.parameterization.fftype import fftype
-    >>> from htmd.parameterization.util import getEquivalentsAndDihedrals, canonicalizeAtomNames
+    >>> from htmd.parameterization.fftype import fftype, _canonicalizeAtomNames
+    >>> from htmd.parameterization.util import getEquivalentsAndDihedrals
     >>> from htmd.molecule.molecule import Molecule
     >>> from htmd.qm.fake import FakeQM
 
@@ -43,7 +43,7 @@ class FakeQM(QMBase):
     >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
     >>> mol = Molecule(molFile)
     >>> fftypemethod = 'GAFF2'
-    >>> mol = canonicalizeAtomNames(mol, fftypemethod)
+    >>> mol = canonicalizeAtomNames(mol)
     >>> parameters, mol = fftype(mol, method=fftypemethod)
     >>> mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
@@ -184,8 +184,7 @@ class FakeQM2(FakeQM):
     >>> from tempfile import TemporaryDirectory
     >>> from htmd.home import home
     >>> from htmd.numbautil import dihedralAngle
-    >>> from htmd.parameterization.fftype import fftype
-    >>> from htmd.parameterization.util import canonicalizeAtomNames
+    >>> from htmd.parameterization.fftype import fftype, _canonicalizeAtomNames
     >>> from htmd.molecule.molecule import Molecule
     >>> from htmd.qm.fake import FakeQM2
 
@@ -193,7 +192,7 @@ class FakeQM2(FakeQM):
     >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
     >>> mol = Molecule(molFile, guessNE='bonds', guess=('angles', 'dihedrals'))
     >>> fftypemethod = 'GAFF2'
-    >>> mol = canonicalizeAtomNames(mol, fftypemethod)
+    >>> mol = canonicalizeAtomNames(mol)
     >>> parameters, mol = fftype(mol, method=fftypemethod)
 
     Run a single-point energy and ESP calculation

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -42,9 +42,7 @@ class FakeQM(QMBase):
     Create a molecule
     >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
     >>> mol = Molecule(molFile)
-    >>> fftypemethod = 'GAFF2'
-    >>> mol = canonicalizeAtomNames(mol)
-    >>> parameters, mol = fftype(mol, method=fftypemethod)
+    >>> parameters, mol = fftype(mol, method='GAFF2')
     >>> mol, equivalents, all_dihedrals = getEquivalentsAndDihedrals(mol)
 
     Run a single-point energy and ESP calculation
@@ -65,9 +63,9 @@ class FakeQM(QMBase):
     >>> result.energy # doctest: +ELLIPSIS
     8.38083...
     >>> result.esp_points
-    array([[ 1.,  1.,  1.]])
+    array([[1., 1., 1.]])
     >>> result.esp_values # doctest: +ELLIPSIS
-    array([ 0.37135...])
+    array([0.37135...])
     >>> np.rad2deg(dihedralAngle(result.coords[[2, 0, 1, 3], :, 0])) # doctest: +ELLIPSIS
     89.99...
 
@@ -191,9 +189,7 @@ class FakeQM2(FakeQM):
     Create a molecule
     >>> molFile = os.path.join(home('test-qm'), 'H2O2-90.mol2')
     >>> mol = Molecule(molFile, guessNE='bonds', guess=('angles', 'dihedrals'))
-    >>> fftypemethod = 'GAFF2'
-    >>> mol = canonicalizeAtomNames(mol)
-    >>> parameters, mol = fftype(mol, method=fftypemethod)
+    >>> parameters, mol = fftype(mol, method='GAFF2')
 
     Run a single-point energy and ESP calculation
     >>> with TemporaryDirectory() as tmpDir:
@@ -213,9 +209,9 @@ class FakeQM2(FakeQM):
     >>> result.energy # doctest: +ELLIPSIS
     8.380840...
     >>> result.esp_points
-    array([[ 1.,  1.,  1.]])
+    array([[1., 1., 1.]])
     >>> result.esp_values # doctest: +ELLIPSIS
-    array([ 0.371352...])
+    array([0.371352...])
     >>> np.rad2deg(dihedralAngle(result.coords[[2, 0, 1, 3], :, 0])) # doctest: +ELLIPSIS
     89.99954...
 

--- a/htmd/qm/fake.py
+++ b/htmd/qm/fake.py
@@ -63,9 +63,9 @@ class FakeQM(QMBase):
     >>> result.energy # doctest: +ELLIPSIS
     8.38083...
     >>> result.esp_points
-    array([[1., 1., 1.]])
+    array([[ 1.,  1.,  1.]])
     >>> result.esp_values # doctest: +ELLIPSIS
-    array([0.37135...])
+    array([ 0.37135...])
     >>> np.rad2deg(dihedralAngle(result.coords[[2, 0, 1, 3], :, 0])) # doctest: +ELLIPSIS
     89.99...
 
@@ -209,9 +209,9 @@ class FakeQM2(FakeQM):
     >>> result.energy # doctest: +ELLIPSIS
     8.380840...
     >>> result.esp_points
-    array([[1., 1., 1.]])
+    array([[ 1.,  1.,  1.]])
     >>> result.esp_values # doctest: +ELLIPSIS
-    array([0.371352...])
+    array([ 0.371352...])
     >>> np.rad2deg(dihedralAngle(result.coords[[2, 0, 1, 3], :, 0])) # doctest: +ELLIPSIS
     89.99954...
 


### PR DESCRIPTION
- [x] Enforce unique atom names
- [x] Clean up element guessing
- [x] Move atom renaming to `fftype` internals
  - [x] Update documentation
- [x] Update tests
- [x] Fix #524 
- [x] Fix #557
- [x] Fix #643 

This is a remake of #781 

Depend on https://github.com/Acellera/htmd-data/pull/10