### PR TITLE
Fixes conda-build

### DIFF
--- a/package/htmd/build.sh
+++ b/package/htmd/build.sh
@@ -39,6 +39,9 @@ else
     exit 1
 fi
 
+# Delete compiled libs from other OS
+find $DIR/htmd/lib -maxdepth 1 ! -name "$OSNAME" ! -path $DIR/htmd/lib -type d -exec rm -rf {} \; -print || true
+
 # copy compiled libs
 if [ -e "$STARTDIR/htmd/lib/$OSNAME" ]; then
     if [ -e "$DIR/htmd/lib/$OSNAME" ]; then


### PR DESCRIPTION
`conda build` of htmd was no longer working anymore with the latest version of `conda-build`. This fixes it. It's urgent and necessary to be merged on other branches as well.