### PR TITLE
prevent charge.py doctest erroring when HTMD_CONFIG is defined

### DIFF
--- a/htmd/charge/charge.py
+++ b/htmd/charge/charge.py
@@ -325,5 +325,10 @@ if __name__ == '__main__':
     import sys
     import doctest
 
+    # Prevent HTMD importing inside doctest to fail if importing gives text output
+    from htmd.home import home
+
+    home()
+
     if doctest.testmod().failed:
         sys.exit(1)


### PR DESCRIPTION
This happens on deployment sites where `HTMD_CONFIG` is defined and the doctest errors because htmd import is no longer silent. Not urgent, but annoying.