### PR TITLE
Force the user to alias >4-letter residue names

### DIFF
--- a/htmd/builder/builder.py
+++ b/htmd/builder/builder.py
@@ -111,7 +111,7 @@ class DisulfideBridge(object):
 def embed(mol1, mol2, gap=1.3):
     '''Embeds one molecule into another removing overlaps.
 
-    Will remove residues of mol1 which have collisions with atoms of mol2.
+    Will remove residues of mol2 which have collisions with atoms of mol1.
 
     Parameters
     ----------
@@ -241,6 +241,12 @@ def _checkMixedSegment(mol):
     if len(intersection) != 0:
         logger.warning('Segments {} contain both protein and non-protein atoms. '
                        'Please assign separate segments to them or the build procedure might fail.'.format(intersection))
+
+
+def _checkLongResnames(mol, aliasresidues):
+    for resname in np.unique(mol.resname):
+        if len(resname) > 4 and resname not in aliasresidues:
+            raise RuntimeError('Too long residue names in Molecule. Please give a 4-letter alias to these residues with the aliasresidues option.')
 
 
 def removeLipidsInProtein(prot, memb, lipidsel='lipids'):

--- a/htmd/builder/charmm.py
+++ b/htmd/builder/charmm.py
@@ -161,7 +161,8 @@ def build(mol, topo=None, param=None, stream=None, prefix='structure', outdir='.
     >>> topos  = ['top/top_all36_prot.rtf', './benzamidine.rtf', 'top/top_water_ions.rtf']
     >>> params = ['par/par_all36_prot_mod.prm', './benzamidine.prm', 'par/par_water_ions.prm']
     >>> disu = [['segid P and resid 157', 'segid P and resid 13'], ['segid K and resid 1', 'segid K and resid 25']]
-    >>> molbuilt = charmm.build(mol, topo=topos, param=params, outdir='/tmp/build', saltconc=0.15, disulfide=disu)  # doctest: +SKIP
+    >>> ar = {'SAPI24': 'SP24'}  # Alias large resnames to a short-hand version
+    >>> molbuilt = charmm.build(mol, topo=topos, param=params, outdir='/tmp/build', saltconc=0.15, disulfide=disu, aliasresidues=ar)  # doctest: +SKIP
     """
 
     mol = mol.copy()


### PR DESCRIPTION
Sometimes i.e. when building membranes you might end up having very long resnames. For example SAPI24 lipids.

The build process needs to write out PDB files, so the resnames get truncated and you get a big bad mess where SAPI24 becomes SAPI which is a different residue in CHARMM etc. 

So here we force the user to alias any resname with more than 4 letters