### PR TITLE
HTMD molecule now points to moleculekit in api.rst

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -9,7 +9,7 @@ Contents:
 .. toctree::
     :maxdepth: 2
 
-    Molecule <molecule>
+    Molecule <../moleculekit/moleculekit.molecule.rst>
     Building <building>
     MD Simulations <simulation>
     Simulation List <htmd.simlist>


### PR DESCRIPTION
Avoids users getting into an empty Molecule page. However, we should eventually delete HTMD Molecule, or create a redirect to Moleculekit, as if you use the search function, old pages will appear.