### PR TITLE
Remove the defunct license activation

### DIFF
--- a/htmdx/cli.py
+++ b/htmdx/cli.py
@@ -179,43 +179,5 @@ def do_register(product=None):
         print("\nCould not register!\n")
 
 
-def main_activate():
-    import sys
-
-    if len(sys.argv) != 2:
-        print(
-            "\n Acellera License Installation\n\n Syntax: activate [activation token]\n\nPlease contact support@acellera.com for licensing\n\n"
-        )
-        sys.exit(0)
-
-    token = sys.argv[1]
-    response = urllib.request.urlopen(
-        "https://licensing.acellera.com/issue/?token=" + token
-    )
-    text = response.read()
-    if isinstance(text, bytes):
-        text = text.decode("ascii")
-
-    if response.status != 200:
-        print("\n Error: " + text + "(" + str(response.status) + ")\n\n")
-    else:
-        prefix = os.path.join(os.path.expanduser("~"), ".acellera")
-        try:
-            os.mkdir(prefix)
-        except:
-            pass
-
-        with open(os.path.join(prefix, "license.dat"), "a") as f:
-            f.write(text)
-
-        print("\n License installed in ~/.acellera/license.dat\n\n")
-        try:
-            with open(os.path.join("/opt/acellera/license.dat"), "a") as f:
-                f.write(text)
-            print("\n License installed in /opt/acellera/license.dat\n\n")
-        except:
-            pass
-
-
 if __name__ == "__main__":
-    main_activate()
+    pass

--- a/package/htmd/meta.yaml
+++ b/package/htmd/meta.yaml
@@ -13,7 +13,6 @@ build:
 
   entry_points:
     - htmd_register   = htmdx.cli:htmd_do_register
-    - activate_license  = htmdx.cli:main_activate
 
 requirements:
   build:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ if __name__ == "__main__":
         entry_points={
             "console_scripts": [
                 "htmd_register   = htmdx.cli:htmd_do_register",
-                "activate_license  = htmdx.cli:main_activate",
             ]
         },
         packages=setuptools.find_packages(include=["htmd*"], exclude=["data"]),


### PR DESCRIPTION
These are defunct from at least 2019. 
- [x] Remove `htmdx.cli.main_activate`
- [x] Remove `activate_license` command