### PR TITLE
Incorrectly set actionspace in AdaptiveBandit

### DIFF
--- a/htmd/adaptive/adaptivebandit.py
+++ b/htmd/adaptive/adaptivebandit.py
@@ -203,7 +203,7 @@ class AdaptiveBandit(AdaptiveBase):
             False,
             val.Boolean(),
         )
-        self._arg("actionspace", "str", "The action space", "tica", val.String())
+        self._arg("actionspace", "str", "The action space", "metric", val.String())
         self._arg(
             "recluster",
             "bool",


### PR DESCRIPTION
In the docstring the actionspace is set by default as  `actionspace='metric'` (line 206). In the code it is set to tica.  